### PR TITLE
Add security code field tooltip.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16913,6 +16913,15 @@
         "scheduler": "^0.13.6"
       }
     },
+    "react-tooltip": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-3.10.0.tgz",
+      "integrity": "sha512-GGdxJvM1zSFztkTP7gCQbLTstWr1OOoMpJ5WZUGhimj0nhRY+MPz+92MpEnKmj0cftJ9Pd/M6FfSl0sfzmZWkg==",
+      "requires": {
+        "classnames": "^2.2.5",
+        "prop-types": "^15.6.0"
+      }
+    },
     "react-transition-group": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "react-responsive": "^6.1.1",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",
+    "react-tooltip": "^3.10.0",
     "react-transition-group": "^2.5.3",
     "redux": "^4.0.1",
     "redux-devtools-extension": "^2.13.2",

--- a/src/payment/CardDetails.jsx
+++ b/src/payment/CardDetails.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { Field } from 'redux-form';
-import { faLock } from '@fortawesome/free-solid-svg-icons';
+import ReactTooltip from 'react-tooltip';
+import { faLock, faQuestionCircle } from '@fortawesome/free-solid-svg-icons';
 import {
   faCcAmex,
   faCcDiscover,
@@ -103,6 +104,16 @@ export class CardDetailsComponent extends React.Component {
                 description="The label for the required credit card security code field"
               />
             </label>
+            <span data-tip data-for="securityCodeHelp">
+              <FontAwesomeIcon icon={faQuestionCircle} />
+            </span>
+            <ReactTooltip id="securityCodeHelp" place="bottom" effect="solid">
+              <FormattedMessage
+                id="payment.card.details.security.code.help.text"
+                defaultMessage="The three last digits in the signature area on the back of your card. For American Express, it is the four digits on the front of the card."
+                description="The help text for the required credit card security code field"
+              />
+            </ReactTooltip>
             <Field
               id="securityCode"
               name="securityCode"

--- a/src/payment/__snapshots__/PaymentPage.test.jsx.snap
+++ b/src/payment/__snapshots__/PaymentPage.test.jsx.snap
@@ -1625,6 +1625,37 @@ exports[`<PaymentPage /> Renders correctly in various states should render error
                   Security Code (required)
                 </span>
               </label>
+              <span
+                data-for="securityCodeHelp"
+                data-tip={true}
+              >
+                <svg
+                  aria-hidden="true"
+                  className="svg-inline--fa fa-question-circle fa-w-16 "
+                  data-icon="question-circle"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  style={Object {}}
+                  viewBox="0 0 512 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                    fill="currentColor"
+                    style={Object {}}
+                  />
+                </svg>
+              </span>
+              <div
+                className="__react_component_tooltip place-bottom type-dark "
+                data-id="tooltip"
+                id="securityCodeHelp"
+              >
+                <span>
+                  The three last digits in the signature area on the back of your card. For American Express, it is the four digits on the front of the card.
+                </span>
+              </div>
               <input
                 className="form-control"
                 name="securityCode"
@@ -3569,6 +3600,37 @@ exports[`<PaymentPage /> Renders correctly in various states should render its l
                   Security Code (required)
                 </span>
               </label>
+              <span
+                data-for="securityCodeHelp"
+                data-tip={true}
+              >
+                <svg
+                  aria-hidden="true"
+                  className="svg-inline--fa fa-question-circle fa-w-16 "
+                  data-icon="question-circle"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  style={Object {}}
+                  viewBox="0 0 512 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                    fill="currentColor"
+                    style={Object {}}
+                  />
+                </svg>
+              </span>
+              <div
+                className="__react_component_tooltip place-bottom type-dark "
+                data-id="tooltip"
+                id="securityCodeHelp"
+              >
+                <span>
+                  The three last digits in the signature area on the back of your card. For American Express, it is the four digits on the front of the card.
+                </span>
+              </div>
               <input
                 className="form-control"
                 name="securityCode"
@@ -5531,6 +5593,37 @@ exports[`<PaymentPage /> Renders correctly in various states should render the b
                   Security Code (required)
                 </span>
               </label>
+              <span
+                data-for="securityCodeHelp"
+                data-tip={true}
+              >
+                <svg
+                  aria-hidden="true"
+                  className="svg-inline--fa fa-question-circle fa-w-16 "
+                  data-icon="question-circle"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  style={Object {}}
+                  viewBox="0 0 512 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                    fill="currentColor"
+                    style={Object {}}
+                  />
+                </svg>
+              </span>
+              <div
+                className="__react_component_tooltip place-bottom type-dark "
+                data-id="tooltip"
+                id="securityCodeHelp"
+              >
+                <span>
+                  The three last digits in the signature area on the back of your card. For American Express, it is the four digits on the front of the card.
+                </span>
+              </div>
               <input
                 className="form-control"
                 name="securityCode"
@@ -7434,6 +7527,37 @@ exports[`<PaymentPage /> Renders correctly in various states should successfully
                   Security Code (required)
                 </span>
               </label>
+              <span
+                data-for="securityCodeHelp"
+                data-tip={true}
+              >
+                <svg
+                  aria-hidden="true"
+                  className="svg-inline--fa fa-question-circle fa-w-16 "
+                  data-icon="question-circle"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
+                  style={Object {}}
+                  viewBox="0 0 512 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                    fill="currentColor"
+                    style={Object {}}
+                  />
+                </svg>
+              </span>
+              <div
+                className="__react_component_tooltip place-bottom type-dark "
+                data-id="tooltip"
+                id="securityCodeHelp"
+              >
+                <span>
+                  The three last digits in the signature area on the back of your card. For American Express, it is the four digits on the front of the card.
+                </span>
+              </div>
               <input
                 className="form-control"
                 name="securityCode"

--- a/src/payment/_style.scss
+++ b/src/payment/_style.scss
@@ -32,3 +32,7 @@
     }
   }
 }
+
+#securityCodeHelp {
+  width: 250px;
+}


### PR DESCRIPTION
<img width="1150" alt="Screen Shot 2019-06-21 at 12 21 31 PM" src="https://user-images.githubusercontent.com/224634/59936906-22c8e900-941f-11e9-9631-08b384ddd13d.png">
