### PR TITLE
rename product name with title

### DIFF
--- a/src/payment/PaymentPage.test.jsx
+++ b/src/payment/PaymentPage.test.jsx
@@ -107,9 +107,9 @@ describe('<PaymentPage />', () => {
 });
 
 const product = {
-  imgUrl: 'https://prod-discovery.edx-cdn.org/media/course/image/21be6203-b140-422c-9233-a1dc278d7266-941abf27df4d.small.jpg',
-  name: 'Introduction to Happiness',
-  seatType: 'verified',
+  imageURL: 'https://prod-discovery.edx-cdn.org/media/course/image/21be6203-b140-422c-9233-a1dc278d7266-941abf27df4d.small.jpg',
+  title: 'Introduction to Happiness',
+  seatType: 'Verified',
 };
 
 describe('<ProductLineItem />', () => {
@@ -141,7 +141,7 @@ describe('<ProductLineItem />', () => {
       expect(tree).toMatchSnapshot();
     });
     it('should render the product details for verified certificate', () => {
-      product.seatType = 'verified';
+      product.seatType = 'Verified';
       const tree = renderer.create((
         <IntlProvider locale="en">
           <ProductLineItem {...product} />

--- a/src/payment/ProductLineItem.jsx
+++ b/src/payment/ProductLineItem.jsx
@@ -13,7 +13,7 @@ class ProductLineItem extends React.PureComponent {
           defaultMessage="Professional Certificate"
           description="Course certificate type on product details section"
         />);
-      case 'verified':
+      case 'Verified':
         return (<FormattedMessage
           id="payment.productlineitem.verified.certificate"
           defaultMessage="Verified Certificate"
@@ -28,17 +28,17 @@ class ProductLineItem extends React.PureComponent {
 
   render() {
     const {
-      imgUrl,
-      name,
+      imageURL,
+      title,
       seatType,
     } = this.props;
     return (
       <div className="row align-items-center">
         <div className="col-5">
-          <img className="img-thumbnail" src={imgUrl} alt={name} />
+          <img className="img-thumbnail" src={imageURL} alt={title} />
         </div>
         <div className="col-7">
-          <h6 className="m-0">{name}</h6>
+          <h6 className="m-0">{title}</h6>
           <p className="m-0">{this.renderSeatType(seatType)}</p>
         </div>
       </div>
@@ -47,9 +47,9 @@ class ProductLineItem extends React.PureComponent {
 }
 
 ProductLineItem.propTypes = {
-  imgUrl: PropTypes.string.isRequired,
-  name: PropTypes.string.isRequired,
-  seatType: PropTypes.oneOf(['professional', 'no-id-professional', 'verified', 'honor', 'audit']),
+  imageURL: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  seatType: PropTypes.oneOf(['professional', 'no-id-professional', 'Verified', 'honor', 'audit']),
 };
 
 ProductLineItem.defaultProps = {

--- a/src/payment/ProductLineItems.jsx
+++ b/src/payment/ProductLineItems.jsx
@@ -24,16 +24,16 @@ function ProductLineItems({ products }) {
           description="Subheading of the cart in product details section"
         />
       </p>
-      {products.map(product => <ProductLineItem {...product} key={product.name} />)}
+      {products.map(product => <ProductLineItem {...product} key={product.title} />)}
     </div>
   );
 }
 
 ProductLineItems.propTypes = {
   products: PropTypes.arrayOf(PropTypes.shape({
-    imgUrl: PropTypes.string,
-    name: PropTypes.string,
-    seatType: PropTypes.oneOf(['professional', 'no-id-professional', 'verified', 'honor', 'audit']),
+    imageURL: PropTypes.string,
+    title: PropTypes.string,
+    seatType: PropTypes.oneOf(['professional', 'no-id-professional', 'Verified', 'honor', 'audit']),
   })),
 };
 

--- a/src/payment/__mocks__/loadedBasket.mockStore.js
+++ b/src/payment/__mocks__/loadedBasket.mockStore.js
@@ -47,10 +47,10 @@ module.exports = {
       totalExclDiscount: 161,
       products: [
         {
-          imgUrl:
+          imageURL:
             'https://prod-discovery.edx-cdn.org/media/course/image/21be6203-b140-422c-9233-a1dc278d7266-941abf27df4d.small.jpg',
-          name: 'Introduction to Happiness',
-          seatType: 'verified',
+          title: 'Introduction to Happiness',
+          seatType: 'Verified',
         },
       ],
       voucher: {

--- a/src/payment/__mocks__/loadedBasketWithNoTotals.mockStore.js
+++ b/src/payment/__mocks__/loadedBasketWithNoTotals.mockStore.js
@@ -45,10 +45,10 @@ module.exports = {
       sdnCheck: true,
       products: [
         {
-          imgUrl:
+          imageURL:
             'https://prod-discovery.edx-cdn.org/media/course/image/21be6203-b140-422c-9233-a1dc278d7266-941abf27df4d.small.jpg',
-          name: 'Introduction to Happiness',
-          seatType: 'verified',
+          title: 'Introduction to Happiness',
+          seatType: 'Verified',
         },
       ],
       voucher: {

--- a/src/payment/data/__mocks__/getBasket.json
+++ b/src/payment/data/__mocks__/getBasket.json
@@ -1,0 +1,30 @@
+{
+  "show_voucher_form": true,
+  "payment_providers": [
+    {
+      "type": "cybersource"
+    },
+    {
+      "type": "paypal"
+    }
+  ],
+  "order_total": 149,
+  "calculated_discount": 12,
+  "total_excl_discount": 161,
+  "sdn_check": true,
+  "products": [
+    {
+      "image_url": "https://prod-discovery.edx-cdn.org/media/course/image/21be6203-b140-422c-9233-a1dc278d7266-941abf27df4d.small.jpg",
+      "name": "Introduction to Happiness",
+      "seat_type": "Verified"
+    }
+  ],
+  "voucher": {
+    "id": 12345,
+    "benefit": {
+      "type": "Percentage",
+      "value": 20
+    },
+    "code": "SUMMER20"
+  }
+}

--- a/src/payment/data/service.js
+++ b/src/payment/data/service.js
@@ -32,8 +32,8 @@ export async function getBasket() {
     orderTotal: Number.parseInt(data.order_total, 10),
     calculatedDiscount: Number.parseInt(data.calculated_discount, 10),
     totalExclDiscount: Number.parseInt(data.total_excl_discount, 10),
-    products: data.products.map(({ img_url: imgUrl, name, seat_type: seatType }) => ({
-      imgUrl, name, seatType,
+    products: data.products.map(({ image_url: imageURL, title, seat_type: seatType }) => ({
+      imageURL, title, seatType,
     })),
     voucher: data.voucher,
   };


### PR DESCRIPTION
WIP: change 'name' to 'title' in product details. 
- Also renamed 'img_url/imgURL' to 'image_url/imageURL' for consistencyl. 
- Locally tested with ecommerce @robrap branch ([PR here](https://github.com/edx/ecommerce/pull/2345)). 

*Side note: 
When running tests, came across a warning for certificate types. Created new ticket [ARCH-997](https://openedx.atlassian.net/browse/ARCH-997) ('Verified' vs. 'verified', i18n). 

FYI @edx/arch-squad 