### PR TITLE
fix: coupons empty array

### DIFF
--- a/src/payment/coupon/CouponForm.jsx
+++ b/src/payment/coupon/CouponForm.jsx
@@ -41,7 +41,7 @@ export class CouponForm extends Component {
     switch (errorCode) {
       // Cases that need a `code`
       case 'empty_basket':
-      case 'already_applied_coupon':
+      case 'already_applied_voucher':
       case 'code_does_not_exist':
       case 'code_expired':
       case 'code_not_active':
@@ -97,11 +97,18 @@ export class CouponForm extends Component {
     return (
       <form onSubmit={this.handleRemoveSubmit} className="d-flex align-items-center mb-3">
         {this.props.benefitValue !== null ?
-          <span>{intl.formatMessage(messages['payment.coupon.benefit_value'], {
+          <span>
+            {intl.formatMessage(messages['payment.coupon.benefit_value'], {
             code,
             value: benefitValue,
-          })}
-          </span> : null}
+            })}
+          </span> :
+          <span>
+            {intl.formatMessage(messages['payment.coupon.benefit.default'], {
+            code,
+            })}
+          </span>
+        }
         <Button className="btn-link display-inline p-0 pl-3 border-0" type="submit">
           {intl.formatMessage(messages['payment.coupon.remove'])}
         </Button>

--- a/src/payment/coupon/CouponForm.test.jsx
+++ b/src/payment/coupon/CouponForm.test.jsx
@@ -57,45 +57,20 @@ describe('CouponForm', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  describe('without logging errors', () => {
-    /**
-     * Explanation: Why do this?  This test is in anticipation of there being coupon types we
-     * didn't expect.  We want the UI to at least display a message in these cases, even if we
-     * weren't expecting them, because the alternative is to show no text at all with a "Remove"
-     * button referencing nothing.  Because this is the basket page, we want to be
-     * over-cautious and let the UI support it in a minimal way.
-     *
-     * We want the CouponForm renderRemove() to continue to warn us about unexpected types in
-     * development, but we want to have good fallback behavior in prod, where the console.errors
-     * won't show up.  Therefore, we're hiding the errors here so that we don't have developers
-     * seeing false positives on test failures (when they aren't actually failures!)
-     */
-    let originalError;
-
-    beforeEach(() => {
-      originalError = console.error; // eslint-disable-line no-console
-      console.error = jest.fn(); // eslint-disable-line no-console
-    });
-
-    afterEach(() => {
-      console.error = originalError; // eslint-disable-line no-console
-    });
-
-    it('should render an unexpected coupon', () => {
-      const component = (
-        <IntlProvider locale="en">
-          <Provider store={mockStore(storeMocks.defaultCouponAdded)}>
-            <ConnectedCouponForm
-              addCoupon={jest.fn()}
-              removeCoupon={jest.fn()}
-              updateCouponDraft={jest.fn()}
-            />
-          </Provider>
-        </IntlProvider>
-      );
-      const tree = renderer.create(component).toJSON();
-      expect(tree).toMatchSnapshot();
-    });
+  it('should render an unexpected coupon', () => {
+    const component = (
+      <IntlProvider locale="en">
+        <Provider store={mockStore(storeMocks.defaultCouponAdded)}>
+          <ConnectedCouponForm
+            addCoupon={jest.fn()}
+            removeCoupon={jest.fn()}
+            updateCouponDraft={jest.fn()}
+          />
+        </Provider>
+      </IntlProvider>
+    );
+    const tree = renderer.create(component).toJSON();
+    expect(tree).toMatchSnapshot();
   });
 
   it('should call addCoupon on form submit', () => {

--- a/src/payment/coupon/CouponForm.test.jsx
+++ b/src/payment/coupon/CouponForm.test.jsx
@@ -65,7 +65,7 @@ describe('CouponForm', () => {
      * button referencing nothing.  Because this is the basket page, we want to be
      * over-cautious and let the UI support it in a minimal way.
      *
-     * We want the Benefit.jsx component to continue to warn us about unexpected types in
+     * We want the CouponForm renderRemove() to continue to warn us about unexpected types in
      * development, but we want to have good fallback behavior in prod, where the console.errors
      * won't show up.  Therefore, we're hiding the errors here so that we don't have developers
      * seeing false positives on test failures (when they aren't actually failures!)
@@ -180,8 +180,8 @@ describe('CouponForm', () => {
       expect(wrapper.find('strong.invalid-feedback').text()).toMatchSnapshot();
     });
 
-    it('should display already_applied_coupon errors correctly', () => {
-      const wrapper = mount(createComponent('already_applied_coupon'));
+    it('should display already_applied_voucher errors correctly', () => {
+      const wrapper = mount(createComponent('already_applied_voucher'));
       expect(wrapper.find('strong.invalid-feedback').text()).toMatchSnapshot();
     });
 

--- a/src/payment/coupon/__snapshots__/CouponForm.test.jsx.snap
+++ b/src/payment/coupon/__snapshots__/CouponForm.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CouponForm error handling should display already_applied_coupon errors correctly 1`] = `"You have already added coupon code 'DEMO25' to your basket."`;
+exports[`CouponForm error handling should display already_applied_voucher errors correctly 1`] = `"You have already added coupon code 'DEMO25' to your basket."`;
 
 exports[`CouponForm error handling should display code_does_not_exist errors correctly 1`] = `"Coupon code 'DEMO25' does not exist."`;
 

--- a/src/payment/coupon/__snapshots__/CouponForm.test.jsx.snap
+++ b/src/payment/coupon/__snapshots__/CouponForm.test.jsx.snap
@@ -121,6 +121,9 @@ exports[`CouponForm without logging errors should render an unexpected coupon 1`
   className="d-flex align-items-center mb-3"
   onSubmit={[Function]}
 >
+  <span>
+    Coupon DEMO25 applied
+  </span>
   <button
     className="btn btn-link display-inline p-0 pl-3 border-0"
     onBlur={[Function]}

--- a/src/payment/coupon/__snapshots__/CouponForm.test.jsx.snap
+++ b/src/payment/coupon/__snapshots__/CouponForm.test.jsx.snap
@@ -79,6 +79,26 @@ exports[`CouponForm should render a percentage coupon 1`] = `
 </form>
 `;
 
+exports[`CouponForm should render an unexpected coupon 1`] = `
+<form
+  className="d-flex align-items-center mb-3"
+  onSubmit={[Function]}
+>
+  <span>
+    Coupon DEMO25 applied
+  </span>
+  <button
+    className="btn btn-link display-inline p-0 pl-3 border-0"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    type="submit"
+  >
+    Remove
+  </button>
+</form>
+`;
+
 exports[`CouponForm should render the add coupon form 1`] = `
 <form
   className="mb-3 d-flex align-items-end"
@@ -112,26 +132,6 @@ exports[`CouponForm should render the add coupon form 1`] = `
     type="submit"
   >
     Apply
-  </button>
-</form>
-`;
-
-exports[`CouponForm without logging errors should render an unexpected coupon 1`] = `
-<form
-  className="d-flex align-items-center mb-3"
-  onSubmit={[Function]}
->
-  <span>
-    Coupon DEMO25 applied
-  </span>
-  <button
-    className="btn btn-link display-inline p-0 pl-3 border-0"
-    onBlur={[Function]}
-    onClick={[Function]}
-    onKeyDown={[Function]}
-    type="submit"
-  >
-    Remove
   </button>
 </form>
 `;

--- a/src/payment/coupon/data/sagas.js
+++ b/src/payment/coupon/data/sagas.js
@@ -23,7 +23,7 @@ export function* handleAddCoupon(action) {
   try {
     const result = yield call(postCoupon, action.payload.code);
     yield put(fetchBasketSuccess(result));
-    if (result.coupons === undefined) {
+    if (result.coupons.length === 0) {
       yield put(addCouponSuccess(null, null, null));
     } else {
       yield put(addCouponSuccess(

--- a/src/payment/coupon/data/sagas.test.js
+++ b/src/payment/coupon/data/sagas.test.js
@@ -59,6 +59,7 @@ describe('saga tests', () => {
       },
       blankVoucherResponse: {
         data: {
+          coupons: [],
           show_coupon_form: true,
           summary_price: 161,
           order_total: 161,

--- a/src/payment/coupon/messages.js
+++ b/src/payment/coupon/messages.js
@@ -21,6 +21,11 @@ const messages = defineMessages({
     defaultMessage: 'Coupon {code} applied for {value} off',
     description: 'The description of a coupon for a percentage off the total price. Percentage symbol is included in {value}',
   },
+  'payment.coupon.benefit.default': {
+    id: 'payment.coupon.benefit.default',
+    defaultMessage: 'Coupon {code} applied',
+    description: 'The description of a coupon without any specific monetary value off.',
+  },
   'payment.coupon.added': {
     id: 'payment.coupon.added',
     defaultMessage: "Coupon code '{code}' was added to your basket.",
@@ -41,8 +46,8 @@ const messages = defineMessages({
     defaultMessage: "Coupon code '{code}' cannot be applied because your basket is empty.",
     description: 'The error message shown to the user when they try to apply a coupon code when their basket is empty.',
   },
-  'payment.coupon.error.already_applied_coupon': {
-    id: 'payment.coupon.error.already_applied_coupon',
+  'payment.coupon.error.already_applied_voucher': {
+    id: 'payment.coupon.error.already_applied_voucher',
     defaultMessage: "You have already added coupon code '{code}' to your basket.",
     description: 'The error message shown to the user when they have already applied a given coupon code to their basket.',
   },

--- a/src/payment/data/sagas.js
+++ b/src/payment/data/sagas.js
@@ -22,7 +22,7 @@ export function* handleFetchBasket() {
   try {
     const result = yield call(PaymentApiService.getBasket);
     yield put(fetchBasketSuccess(result));
-    if (result.coupons[0] === undefined) {
+    if (result.coupons.length === 0) {
       yield put(addCouponSuccess(null, null, null));
     } else {
       yield put(addCouponSuccess(


### PR DESCRIPTION
- Changed `result.coupons === undefined` to `result.coupons.length === 0` to handle when a coupon is removed (coupons returns as an empty array). 
- On CouponForm errors, `already_applied_voucher` should still be referred to 'voucher', not 'coupons'.
- Added back default benefit message to handle coupons with just a code, no value.  