### PR TITLE
refactor: add scroll to error on submit

### DIFF
--- a/src/payment/PaymentForm.jsx
+++ b/src/payment/PaymentForm.jsx
@@ -137,6 +137,16 @@ export class PaymentFormComponent extends React.Component {
     Object.keys(values).forEach((key) => {
       if (!values[key]) {
         errors[key] = this.props.intl.formatMessage(messages['payment.form.errors.required.field']);
+
+        // scroll to error
+        const formElement = document.getElementsByName(`${key}`);
+        const topOfParent = formElement[0].offsetParent.offsetParent.offsetTop - 10;
+        const topOfElement = formElement[0].offsetParent.offsetTop + topOfParent;
+        window.scrollTo({
+          top: topOfElement,
+          left: 0,
+          behavior: 'smooth',
+        });
       }
     });
 

--- a/src/payment/PaymentForm.jsx
+++ b/src/payment/PaymentForm.jsx
@@ -45,6 +45,7 @@ export class PaymentFormComponent extends React.Component {
 
     const errors = {
       ...this.validateRequiredFields(requiredFields),
+      ...this.scrollToErrors(requiredFields),
       ...this.validateCardDetails(
         cardNumber,
         securityCode,
@@ -134,22 +135,16 @@ export class PaymentFormComponent extends React.Component {
   validateRequiredFields(values) {
     const errors = {};
 
-    Object.keys(values).forEach((key, index) => {
+    Object.keys(values).forEach((key) => {
       if (!values[key]) {
         errors[key] = this.props.intl.formatMessage(messages['payment.form.errors.required.field']);
-
-        if (index === 0) {
-          const form = this.formRef.current;
-          const formElement = form.querySelector(`[name=${key}]`);
-          const elementLabel = formElement.previousElementSibling;
-          elementLabel.scrollIntoView(true);
-        }
       }
     });
 
     return errors;
   }
 
+<<<<<<< HEAD
   renderPaymentProviderFormFields() {
     const { paymentProcessorFormFields } = this.props;
     const formFields = [];
@@ -157,6 +152,15 @@ export class PaymentFormComponent extends React.Component {
       formFields.push(<input type="hidden" key={key} name={key} value={paymentProcessorFormFields[key]} />);
     });
     return formFields;
+=======
+  scrollToErrors(values) {
+    const firstErrorIndex = Object.values(values).indexOf(undefined);
+    const firstErrorName = Object.keys(values)[firstErrorIndex];
+    const form = this.formRef.current;
+    const formElement = form.querySelector(`[name=${firstErrorName}]`);
+    const elementLabel = formElement.previousElementSibling;
+    elementLabel.scrollIntoView(true);
+>>>>>>> refactor: added scroll in separate function
   }
 
   render() {

--- a/src/payment/PaymentForm.jsx
+++ b/src/payment/PaymentForm.jsx
@@ -144,15 +144,6 @@ export class PaymentFormComponent extends React.Component {
     return errors;
   }
 
-<<<<<<< HEAD
-  renderPaymentProviderFormFields() {
-    const { paymentProcessorFormFields } = this.props;
-    const formFields = [];
-    Object.keys(paymentProcessorFormFields).forEach((key) => {
-      formFields.push(<input type="hidden" key={key} name={key} value={paymentProcessorFormFields[key]} />);
-    });
-    return formFields;
-=======
   scrollToErrors(values) {
     const firstErrorIndex = Object.values(values).indexOf(undefined);
     const firstErrorName = Object.keys(values)[firstErrorIndex];
@@ -160,7 +151,15 @@ export class PaymentFormComponent extends React.Component {
     const formElement = form.querySelector(`[name=${firstErrorName}]`);
     const elementLabel = formElement.previousElementSibling;
     elementLabel.scrollIntoView(true);
->>>>>>> refactor: added scroll in separate function
+  }
+
+  renderPaymentProviderFormFields() {
+    const { paymentProcessorFormFields } = this.props;
+    const formFields = [];
+    Object.keys(paymentProcessorFormFields).forEach((key) => {
+      formFields.push(<input type="hidden" key={key} name={key} value={paymentProcessorFormFields[key]} />);
+    });
+    return formFields;
   }
 
   render() {

--- a/src/payment/PaymentForm.jsx
+++ b/src/payment/PaymentForm.jsx
@@ -148,8 +148,10 @@ export class PaymentFormComponent extends React.Component {
   scrollToError(error) {
     const form = this.formRef.current;
     const formElement = form.querySelector(`[name=${error}]`);
-    const elementLabel = formElement.previousElementSibling;
-    elementLabel.scrollIntoView(true);
+    if (formElement) {
+      const elementParent = formElement.parentElement;
+      elementParent.scrollIntoView(true);
+    }
   }
 
   renderPaymentProviderFormFields() {

--- a/src/payment/PaymentForm.jsx
+++ b/src/payment/PaymentForm.jsx
@@ -134,14 +134,16 @@ export class PaymentFormComponent extends React.Component {
   validateRequiredFields(values) {
     const errors = {};
 
-    Object.keys(values).forEach((key) => {
+    Object.keys(values).forEach((key, index) => {
       if (!values[key]) {
         errors[key] = this.props.intl.formatMessage(messages['payment.form.errors.required.field']);
 
-        const form = this.formRef.current;
-        const formElement = form.querySelector(`[name=${key}]`);
-        const elementLabel = formElement.previousElementSibling;
-        elementLabel.scrollIntoView(true);
+        if (index === 0) {
+          const form = this.formRef.current;
+          const formElement = form.querySelector(`[name=${key}]`);
+          const elementLabel = formElement.previousElementSibling;
+          elementLabel.scrollIntoView(true);
+        }
       }
     });
 

--- a/src/payment/PaymentForm.jsx
+++ b/src/payment/PaymentForm.jsx
@@ -138,15 +138,10 @@ export class PaymentFormComponent extends React.Component {
       if (!values[key]) {
         errors[key] = this.props.intl.formatMessage(messages['payment.form.errors.required.field']);
 
-        // scroll to error
-        const formElement = document.getElementsByName(`${key}`);
-        const topOfParent = formElement[0].offsetParent.offsetParent.offsetTop - 10;
-        const topOfElement = formElement[0].offsetParent.offsetTop + topOfParent;
-        window.scrollTo({
-          top: topOfElement,
-          left: 0,
-          behavior: 'smooth',
-        });
+        const form = this.formRef.current;
+        const formElement = form.querySelector(`[name=${key}]`);
+        const elementLabel = formElement.previousElementSibling;
+        elementLabel.scrollIntoView(true);
       }
     });
 

--- a/src/payment/PaymentForm.jsx
+++ b/src/payment/PaymentForm.jsx
@@ -45,7 +45,6 @@ export class PaymentFormComponent extends React.Component {
 
     const errors = {
       ...this.validateRequiredFields(requiredFields),
-      ...this.scrollToErrors(requiredFields),
       ...this.validateCardDetails(
         cardNumber,
         securityCode,
@@ -55,6 +54,8 @@ export class PaymentFormComponent extends React.Component {
     };
 
     if (Object.keys(errors).length > 0) {
+      const firstErrorName = Object.keys(errors)[0];
+      this.scrollToError(firstErrorName);
       throw new SubmissionError(errors);
     }
 
@@ -144,11 +145,9 @@ export class PaymentFormComponent extends React.Component {
     return errors;
   }
 
-  scrollToErrors(values) {
-    const firstErrorIndex = Object.values(values).indexOf(undefined);
-    const firstErrorName = Object.keys(values)[firstErrorIndex];
+  scrollToError(error) {
     const form = this.formRef.current;
-    const formElement = form.querySelector(`[name=${firstErrorName}]`);
+    const formElement = form.querySelector(`[name=${error}]`);
     const elementLabel = formElement.previousElementSibling;
     elementLabel.scrollIntoView(true);
   }

--- a/src/payment/PaymentForm.test.jsx
+++ b/src/payment/PaymentForm.test.jsx
@@ -18,16 +18,20 @@ const storeMocks = {
 configureI18n(configuration, messages);
 
 describe('<PaymentForm />', () => {
+  let wrapper;
+  let paymentForm;
+  beforeEach(() => {
+    wrapper = mount((
+      <IntlProvider locale="en">
+        <Provider store={mockStore(storeMocks.defaultState)}>
+          <PaymentForm handleSubmit={() => {}} />
+        </Provider>
+      </IntlProvider>
+    ));
+    paymentForm = wrapper.find(PaymentFormComponent).first().instance();
+  });
   describe('getRequiredFields', () => {
     it('returns expected required fields', () => {
-      const wrapper = mount((
-        <IntlProvider locale="en">
-          <Provider store={mockStore(storeMocks.defaultState)}>
-            <PaymentForm handleSubmit={() => {}} />
-          </Provider>
-        </IntlProvider>
-      ));
-      const paymentForm = wrapper.find(PaymentFormComponent).first().instance();
       const testFormValues = [
         {
           firstName: '',
@@ -81,14 +85,6 @@ describe('<PaymentForm />', () => {
   });
   describe('onSubmit', () => {
     it('throws expected errors', () => {
-      const wrapper = mount((
-        <IntlProvider locale="en">
-          <Provider store={mockStore(storeMocks.defaultState)}>
-            <PaymentForm handleSubmit={() => {}} />
-          </Provider>
-        </IntlProvider>
-      ));
-      const paymentForm = wrapper.find(PaymentFormComponent).first().instance();
       paymentForm.validateRequiredFields = jest.fn();
       paymentForm.validateCardDetails = jest.fn();
       paymentForm.scrollToError = jest.fn();
@@ -136,14 +132,6 @@ describe('<PaymentForm />', () => {
   });
   describe('validateCardDetails', () => {
     it('returns expected errors', () => {
-      const wrapper = mount((
-        <IntlProvider locale="en">
-          <Provider store={mockStore(storeMocks.defaultState)}>
-            <PaymentForm handleSubmit={() => {}} />
-          </Provider>
-        </IntlProvider>
-      ));
-      const paymentForm = wrapper.find(PaymentFormComponent).first().instance();
       const currentMonth = new Date().getMonth() + 1;
       const currentYear = new Date().getFullYear();
       const testData = [
@@ -167,14 +155,6 @@ describe('<PaymentForm />', () => {
   });
   describe('validateRequiredFields', () => {
     it('returns errors if values are empty', () => {
-      const wrapper = mount((
-        <IntlProvider locale="en">
-          <Provider store={mockStore(storeMocks.defaultState)}>
-            <PaymentForm handleSubmit={() => {}} />
-          </Provider>
-        </IntlProvider>
-      ));
-      const paymentForm = wrapper.find(PaymentFormComponent).first().instance();
       const values = {
         firsName: 'Jane',
         lastName: undefined,
@@ -186,19 +166,8 @@ describe('<PaymentForm />', () => {
     });
   });
   describe('scrollToError', () => {
-    let wrapper;
-    beforeEach(() => {
-      wrapper = mount((
-        <IntlProvider locale="en">
-          <Provider store={mockStore(storeMocks.defaultState)}>
-            <PaymentForm handleSubmit={() => {}} />
-          </Provider>
-        </IntlProvider>
-      ));
-    });
     it('scrolls to the input name of the first error', () => {
       global.HTMLElement.prototype.scrollIntoView = jest.fn();
-      const paymentForm = wrapper.find(PaymentFormComponent).first().instance();
       const error = 'firstName';
       paymentForm.scrollToError(error);
       expect(global.HTMLElement.prototype.scrollIntoView).toHaveBeenCalled();

--- a/src/payment/PaymentForm.test.jsx
+++ b/src/payment/PaymentForm.test.jsx
@@ -165,6 +165,7 @@ describe('<PaymentForm />', () => {
   });
   describe('validateRequiredFields', () => {
     it('returns errors if values are empty', () => {
+      window.HTMLElement.prototype.scrollIntoView = function test() {};
       const wrapper = mount((
         <IntlProvider locale="en">
           <Provider store={mockStore(storeMocks.defaultState)}>

--- a/src/payment/PaymentForm.test.jsx
+++ b/src/payment/PaymentForm.test.jsx
@@ -91,7 +91,7 @@ describe('<PaymentForm />', () => {
       const paymentForm = wrapper.find(PaymentFormComponent).first().instance();
       paymentForm.validateRequiredFields = jest.fn();
       paymentForm.validateCardDetails = jest.fn();
-      paymentForm.scrollToErrors = jest.fn();
+      paymentForm.scrollToError = jest.fn();
       const testFormValues = {
         firstName: '',
         lastName: '',
@@ -124,7 +124,7 @@ describe('<PaymentForm />', () => {
 
       testData.forEach((testCaseData) => {
         paymentForm.validateRequiredFields.mockReturnValueOnce(testCaseData[0]);
-        paymentForm.scrollToErrors.mockReturnValueOnce(testCaseData[0]);
+        paymentForm.scrollToError.mockReturnValueOnce(testCaseData[0]);
         paymentForm.validateCardDetails.mockReturnValueOnce(testCaseData[1]);
         if (testCaseData[2]) {
           expect(() => paymentForm.onSubmit(testFormValues)).toThrow(testCaseData[2]);

--- a/src/payment/PaymentForm.test.jsx
+++ b/src/payment/PaymentForm.test.jsx
@@ -174,14 +174,29 @@ describe('<PaymentForm />', () => {
       ));
       const paymentForm = wrapper.find(PaymentFormComponent).first().instance();
       const values = {
-        valid: 'Good!',
-        invalid: '',
+        firsName: 'Jane',
+        lastName: undefined,
       };
       const expectedErrors = {
-        invalid: 'This field is required',
+        lastName: 'This field is required',
       };
-
       expect(paymentForm.validateRequiredFields(values)).toEqual(expectedErrors);
+    });
+  });
+  describe('scrollToError', () => {
+    it('scrolls to the input name of the first error', () => {
+      const wrapper = mount((
+        <IntlProvider locale="en">
+          <Provider store={mockStore(storeMocks.defaultState)}>
+            <PaymentForm handleSubmit={() => {}} />
+          </Provider>
+        </IntlProvider>
+      ));
+      const paymentForm = wrapper.find(PaymentFormComponent).first().instance();
+      global.HTMLElement.prototype.scrollIntoView = jest.fn();
+      const error = 'firstName';
+      paymentForm.scrollToError(error);
+      expect(global.HTMLElement.prototype.scrollIntoView).toHaveBeenCalled();
     });
   });
 });

--- a/src/payment/PaymentForm.test.jsx
+++ b/src/payment/PaymentForm.test.jsx
@@ -186,16 +186,19 @@ describe('<PaymentForm />', () => {
     });
   });
   describe('scrollToError', () => {
-    it('scrolls to the input name of the first error', () => {
-      const wrapper = mount((
+    let wrapper;
+    beforeEach(() => {
+      wrapper = mount((
         <IntlProvider locale="en">
           <Provider store={mockStore(storeMocks.defaultState)}>
             <PaymentForm handleSubmit={() => {}} />
           </Provider>
         </IntlProvider>
       ));
-      const paymentForm = wrapper.find(PaymentFormComponent).first().instance();
+    });
+    it('scrolls to the input name of the first error', () => {
       global.HTMLElement.prototype.scrollIntoView = jest.fn();
+      const paymentForm = wrapper.find(PaymentFormComponent).first().instance();
       const error = 'firstName';
       paymentForm.scrollToError(error);
       expect(global.HTMLElement.prototype.scrollIntoView).toHaveBeenCalled();

--- a/src/payment/PaymentForm.test.jsx
+++ b/src/payment/PaymentForm.test.jsx
@@ -91,6 +91,7 @@ describe('<PaymentForm />', () => {
       const paymentForm = wrapper.find(PaymentFormComponent).first().instance();
       paymentForm.validateRequiredFields = jest.fn();
       paymentForm.validateCardDetails = jest.fn();
+      paymentForm.scrollToErrors = jest.fn();
       const testFormValues = {
         firstName: '',
         lastName: '',
@@ -123,6 +124,7 @@ describe('<PaymentForm />', () => {
 
       testData.forEach((testCaseData) => {
         paymentForm.validateRequiredFields.mockReturnValueOnce(testCaseData[0]);
+        paymentForm.scrollToErrors.mockReturnValueOnce(testCaseData[0]);
         paymentForm.validateCardDetails.mockReturnValueOnce(testCaseData[1]);
         if (testCaseData[2]) {
           expect(() => paymentForm.onSubmit(testFormValues)).toThrow(testCaseData[2]);
@@ -165,7 +167,6 @@ describe('<PaymentForm />', () => {
   });
   describe('validateRequiredFields', () => {
     it('returns errors if values are empty', () => {
-      window.HTMLElement.prototype.scrollIntoView = function test() {};
       const wrapper = mount((
         <IntlProvider locale="en">
           <Provider store={mockStore(storeMocks.defaultState)}>


### PR DESCRIPTION
Added `scrollToErrors` where onSubmit of the Payment form, it scrolls to the error message. If there are multiple errors in the form's input fields, scrolls to first error. 
[ARCH-939](https://openedx.atlassian.net/browse/ARCH-939). 