### PR TITLE
feat: add optimizely snippet to top of head

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en-us">
   <head>
-      <title>Payment | edX</title>
-      <meta charset="utf-8">
-      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <% if (htmlWebpackPlugin.options.optimizelyId) { %>
+    <script src="https://cdn.optimizely.com/js/<%= htmlWebpackPlugin.options.optimizelyId %>.js"></script>
+    <% } %>
+    <title>Payment | edX</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
   </head>
   <body>
     <div id="root"></div>

--- a/webpack/webpack.common.config.js
+++ b/webpack/webpack.common.config.js
@@ -60,6 +60,7 @@ module.exports = {
     new HtmlWebpackPlugin({
       inject: true, // Appends script tags linking to the webpack bundles at the end of the body
       template: path.resolve(__dirname, '../public/index.html'),
+      optimizelyId: process.env.OPTIMIZELY_PROJECT_ID,
     }),
   ],
 };


### PR DESCRIPTION
The webpack html template will now produce like below if `process.env.OPTIMIZELY_PROJECT_ID` exists. (Companion PR: https://github.com/edx/edx-internal/pull/1010)

```
<!DOCTYPE html>
<html lang="en-us">
<head>
    <script src="https://cdn.optimizely.com/js/1234.js"></script>
    ...
```
