### PR TITLE
feat: send errors to NR and add fallback error message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1561,9 +1561,9 @@
       }
     },
     "@edx/frontend-logging": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-logging/-/frontend-logging-2.0.3.tgz",
-      "integrity": "sha512-8PnHKW+LAOjXfJEdaxxI449iCVG6SNM+4DO1n8x6BoZZEpmy9fLgvmvIhMrPjrlPNTMSlcAC78mmpYUC3rSslg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-logging/-/frontend-logging-2.1.0.tgz",
+      "integrity": "sha512-IN0Bgh0/1Ax3TMPfZztqzdJchW4B5Px9PT4V9uu6TMj2Cj8el1CV3jrSA4Idg8C3CAkFZ/EHjmaFVCxgJ9aXVA=="
     },
     "@edx/paragon": {
       "version": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@edx/frontend-auth": "^5.3.4",
     "@edx/frontend-component-site-header": "^2.3.0",
     "@edx/frontend-i18n": "^2.1.0",
-    "@edx/frontend-logging": "^2.0.2",
+    "@edx/frontend-logging": "^2.1.0",
     "@edx/paragon": "^6.0.2",
     "@fortawesome/fontawesome-svg-core": "^1.2.14",
     "@fortawesome/free-brands-svg-icons": "^5.7.2",

--- a/src/common/serviceUtils.js
+++ b/src/common/serviceUtils.js
@@ -1,5 +1,7 @@
 import pick from 'lodash.pick';
+import { logAPIErrorResponse, logInfo } from '@edx/frontend-logging';
 import { camelCaseObject } from './utils';
+
 
 export function applyConfiguration(expected, actual) {
   Object.keys(expected).forEach((key) => {
@@ -85,21 +87,25 @@ function handleApiMessages(messages) {
 export function handleRequestError(error) {
   // Validation errors
   if (error.response && error.response.data.field_errors) {
+    logInfo('Field Errors', error.response.data.field_errors);
     handleFieldErrors(error.response.data.field_errors);
   }
 
   // API errors
   if (error.response && error.response.data.errors !== undefined) {
+    logInfo('API Errors', error.response.data.errors);
     handleApiErrors(error.response.data.errors);
   }
 
   // API messages
   if (error.response && error.response.data.messages !== undefined) {
+    logInfo('API Messages', error.response.data.messages);
     handleApiMessages(error.response.data.messages);
   }
 
   // Single API error
   if (error.response && error.response.data.error_code) {
+    logInfo('API Error', error.response.data.errors);
     handleApiErrors([
       {
         error_code: error.response.data.error_code,
@@ -109,5 +115,6 @@ export function handleRequestError(error) {
   }
 
   // Other errors
+  logAPIErrorResponse(error);
   throw error;
 }

--- a/src/feedback/AlertList.jsx
+++ b/src/feedback/AlertList.jsx
@@ -5,8 +5,18 @@ import { connect } from 'react-redux';
 import AlertMessage from './AlertMessage';
 import { alertListMapStateToProps } from './data/selectors';
 import { removeMessage } from './data/actions';
+import FallbackErrorMessage from './FallbackErrorMessage';
 
 class AlertList extends Component {
+  getUserMessage(code, userMessage) {
+    if (this.props.messageCodes[code]) {
+      return this.props.messageCodes[code];
+    } else if (code === 'fallback-error') {
+      return FallbackErrorMessage;
+    }
+    return userMessage;
+  }
+
   render() {
     if (this.props.messageList.length < 1) {
       return null;
@@ -17,10 +27,7 @@ class AlertList extends Component {
         {...messageProps}
         key={messageProps.id}
         closeHandler={this.props.removeMessage}
-        userMessage={this.props.messageCodes[code] ?
-          this.props.messageCodes[code] :
-          userMessage
-        }
+        userMessage={this.getUserMessage(code, userMessage)}
       />
     ));
   }

--- a/src/feedback/AlertMessage.jsx
+++ b/src/feedback/AlertMessage.jsx
@@ -34,7 +34,10 @@ const AlertMessage = (props) => {
   if (typeof userMessage === 'function') {
     statusAlertProps.dialog = React.createElement(userMessage, { values: data });
   } else if (React.isValidElement(userMessage)) {
-    statusAlertProps.dialog = React.cloneElement(userMessage, { values: data });
+    statusAlertProps.dialog = React.cloneElement(userMessage, {
+      ...userMessage.props,
+      values: { ...data, ...userMessage.props.values },
+    });
   } else {
     statusAlertProps.dialog = userMessage;
   }

--- a/src/feedback/FallbackErrorMessage.jsx
+++ b/src/feedback/FallbackErrorMessage.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from '@edx/frontend-i18n';
+import { connect } from 'react-redux';
+import { Hyperlink } from '@edx/paragon';
+
+const FallbackErrorMessage = ({ supportURL }) => (
+  <FormattedMessage
+    id="payment.error.fetch.basket"
+    defaultMessage="There was an unexpected problem. If the problem persists, please {supportLink}."
+    description="The error message when a basket fails to load"
+    values={{
+      supportLink: (
+        <Hyperlink destination={supportURL}>
+          <FormattedMessage
+            id="payment.error.fetch.basket.support.fragment"
+            defaultMessage="contact support"
+            description="The support link as in 'please {contact support}'"
+          />
+        </Hyperlink>
+      ),
+    }}
+  />
+);
+
+FallbackErrorMessage.propTypes = {
+  supportURL: PropTypes.string.isRequired,
+};
+
+const mapStateToProps = state => ({
+  supportURL: state.configuration.SUPPORT_URL,
+});
+
+export default connect(mapStateToProps)(FallbackErrorMessage);

--- a/src/feedback/__mocks__/messagesOfEachType.mockStore.js
+++ b/src/feedback/__mocks__/messagesOfEachType.mockStore.js
@@ -1,4 +1,7 @@
 module.exports = {
+  configuration: {
+    SUPPORT_URL: 'url',
+  },
   feedback: {
     byId: {
       2: {
@@ -39,7 +42,13 @@ module.exports = {
         userMessage: 'Debug debug',
         messageType: 'debug',
       },
+      7: {
+        id: 7,
+        code: 'fallback-error',
+        userMessage: null,
+        messageType: 'error',
+      },
     },
-    orderedIds: [2, 3, 4, 5, 6],
+    orderedIds: [2, 3, 4, 5, 6, 7],
   },
 };

--- a/src/feedback/__snapshots__/AlertList.test.jsx.snap
+++ b/src/feedback/__snapshots__/AlertList.test.jsx.snap
@@ -129,5 +129,42 @@ Array [
       Debug debug
     </div>
   </div>,
+  <div
+    className="alert fade alert-dismissible alert-danger show"
+    hidden={false}
+    role="alert"
+  >
+    <button
+      aria-label="Close"
+      className="btn close"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      type="button"
+    >
+      <span
+        aria-hidden="true"
+      >
+        ×
+      </span>
+    </button>
+    <div
+      className="alert-dialog"
+    >
+      <span>
+        There was an unexpected problem. If the problem persists, please 
+        <a
+          href="url"
+          onClick={[Function]}
+          target="_self"
+        >
+          <span>
+            contact support
+          </span>
+        </a>
+        .
+      </span>
+    </div>
+  </div>,
 ]
 `;

--- a/src/feedback/data/sagas.js
+++ b/src/feedback/data/sagas.js
@@ -4,9 +4,9 @@ import { addMessage } from './actions';
 import { MESSAGE_TYPES } from './constants';
 
 export function* handleErrors(e) {
-  // If this doesn't contain anything we understand, bail.
+  // If this doesn't contain anything we understand, add a fallback error message
   if (e.errors === undefined && e.fieldErrors === undefined && e.messages === undefined) {
-    throw e;
+    yield put(addMessage('fallback-error', null, {}, MESSAGE_TYPES.ERROR));
   }
   if (e.errors !== undefined) {
     for (let i = 0; i < e.errors.length; i++) { // eslint-disable-line no-plusplus

--- a/src/feedback/data/sagas.test.js
+++ b/src/feedback/data/sagas.test.js
@@ -13,7 +13,7 @@ describe('saga tests', () => {
     error = new Error();
   });
 
-  it('should throw on unexpected errors', async () => {
+  it('should add a fallback error on unexpected errors', async () => {
     try {
       await runSaga(
         {
@@ -24,7 +24,10 @@ describe('saga tests', () => {
         error,
       ).toPromise();
     } catch (e) {} // eslint-disable-line no-empty
-    expect(caughtErrors).toEqual([error]);
+
+    const lastAction = dispatched[dispatched.length - 1];
+    expect(lastAction.payload).toEqual(expect.objectContaining({ code: 'fallback-error' }));
+    expect(caughtErrors).toEqual([]);
   });
 
   it('should dispatch addMessage actions on API errors', async () => {

--- a/src/payment/coupon/data/sagas.test.js
+++ b/src/payment/coupon/data/sagas.test.js
@@ -16,6 +16,13 @@ import { fetchBasketSuccess } from '../../data/actions';
 import { transformResults } from '../../data/service';
 import { addMessage, MESSAGE_TYPES } from '../../../feedback';
 
+
+jest.mock('@edx/frontend-logging', () => ({
+  logAPIErrorResponse: jest.fn(),
+  logInfo: jest.fn(),
+}));
+
+
 describe('saga tests', () => {
   const configuration = {
     ECOMMERCE_BASE_URL: 'http://localhost',
@@ -219,7 +226,11 @@ describe('saga tests', () => {
         expect(e).toEqual('oh snap!');
       }
 
-      expect(caughtErrors).toEqual(['oh snap!']);
+      const lastAction = dispatched[dispatched.length - 1];
+      expect(lastAction)
+        .toEqual(addMessage('fallback-error', null, {}, MESSAGE_TYPES.ERROR));
+
+      expect(caughtErrors).toEqual([]);
 
       expect(apiClientPost).toHaveBeenCalledWith(
         'http://localhost/bff/payment/v0/vouchers/',
@@ -356,7 +367,9 @@ describe('saga tests', () => {
         expect(e).toEqual('oh snap!');
       }
 
-      expect(caughtErrors).toEqual(['oh snap!']);
+      const lastAction = dispatched[dispatched.length - 1];
+      expect(lastAction)
+        .toEqual(addMessage('fallback-error', null, {}, MESSAGE_TYPES.ERROR));
 
       expect(apiClientDelete).toHaveBeenCalledWith('http://localhost/bff/payment/v0/vouchers/12345');
     });

--- a/src/payment/data/reducers.js
+++ b/src/payment/data/reducers.js
@@ -29,7 +29,7 @@ const basket = (state = basketInitialState, action = null) => {
       return {
         ...state,
         loading: false,
-        loaded: true,
+        loaded: false,
       };
     case SUBMIT_PAYMENT.BEGIN:
       return {


### PR DESCRIPTION
<img width="890" alt="Screen Shot 2019-07-22 at 9 22 36 AM" src="https://user-images.githubusercontent.com/1615421/61635779-4a031800-ac62-11e9-8722-54b3e9c00806.png">

Log info and errors to New Relic on request errors. Update `handleErrors` to provide a fallback error message rather than bailing.