### PR TITLE
Fail commit on npm audit vulnerabilities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ script:
   - make validate-no-uncommitted-package-lock-changes
   - npm run i18n_extract
   - npm run lint
+  - npm audit
   - npm run test
   - npm run build
   - npm run is-es5

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ tx_url2 = https://www.transifex.com/api/2/project/edx-platform/resource/$(transi
 # This directory must match .babelrc .
 transifex_temp = ./temp/babel-plugin-react-intl
 
+precommit:
+	npm run lint
+	npm audit
+
 requirements:
 	npm install
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "i18n_extract": "BABEL_ENV=i18n babel src --quiet > /dev/null",
     "is-es5": "es-check es5 ./dist/*.js",
     "lint": "eslint --ext .js --ext .jsx .",
-    "precommit": "npm run lint",
+    "precommit": "make precommit",
     "snapshot": "jest --updateSnapshot",
     "start": "NODE_ENV=development BABEL_ENV=development webpack-dev-server --config=webpack/webpack.dev.config.js --progress",
     "start:stage": "NODE_ENV=development BABEL_ENV=development webpack-dev-server --config=webpack/webpack.dev-stage.config.js --progress --disable-host-check",


### PR DESCRIPTION
`npm audit` kindly returns a non-zero exit status on any failure.

Note that it also has an `--audit-level` parameter we can choose to use if we want more granular control over what constitutes a failure.  For now it'll fail on any vulnerability.

https://docs.npmjs.com/cli/audit