### PR TITLE
Removing dependency on font-awesome package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "classnames": "2.2.6",
     "connected-react-router": "5.0.1",
     "email-prop-type": "1.1.7",
-    "font-awesome": "4.7.0",
     "form-urlencoded": "3.0.0",
     "glob": "7.1.4",
     "history": "4.9.0",

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,8 +1,5 @@
 @import "~@edx/edx-bootstrap/scss/edx/theme.scss";
 
-$fa-font-path: "~font-awesome/fonts";
-@import "~font-awesome/scss/font-awesome";
-
 @import "~@edx/paragon/src/index.scss";
 @import "~@edx/frontend-component-site-header/src/index";
 


### PR DESCRIPTION
Saves us about 2k in CSS.  Didn't impact font downloads as we weren't using the FontAwesome font face.  This _does_ remove several extra files from our dist bundle, though they were never being downloaded by the client.  ¯\_(ツ)_/¯

This was for https://openedx.atlassian.net/browse/ARCH-1052