### PR TITLE
fix: make newlines from spaces in apple verification config

### DIFF
--- a/build.prod.js
+++ b/build.prod.js
@@ -16,7 +16,7 @@ webpack(config, (err, stats) => { // Stats Object
   let fileContents;
 
   if (process.env.APPLE_DEVELOPER_MERCHANT_ID_DOMAIN_ASSOCIATION) {
-    fileContents = process.env.APPLE_DEVELOPER_MERCHANT_ID_DOMAIN_ASSOCIATION;
+    fileContents = process.env.APPLE_DEVELOPER_MERCHANT_ID_DOMAIN_ASSOCIATION.replace(/ /g, '\n');
   } else {
     fileContents = `
 No domain association file was supplied. \n\n

--- a/build.prod.js
+++ b/build.prod.js
@@ -16,6 +16,9 @@ webpack(config, (err, stats) => { // Stats Object
   let fileContents;
 
   if (process.env.APPLE_DEVELOPER_MERCHANT_ID_DOMAIN_ASSOCIATION) {
+    // Replace spaces with newlines for apple verification file because
+    // build config values can't have newlines in them. We use spaces
+    // to represent newlines instead.
     fileContents = process.env.APPLE_DEVELOPER_MERCHANT_ID_DOMAIN_ASSOCIATION.replace(/ /g, '\n');
   } else {
     fileContents = `


### PR DESCRIPTION
Build config values can't have newlines in them yet so for apple verification config we're using spaces instead. We will replace spaces with newlines when we write out the apple verification file at build time. Companion PR: https://github.com/edx/edx-internal/pull/1028