### PR TITLE
fix: remove heading css, replace with aria-level

### DIFF
--- a/src/payment/CardDetails.jsx
+++ b/src/payment/CardDetails.jsx
@@ -53,13 +53,13 @@ export class CardDetailsComponent extends React.Component {
     const { submitting } = this.props;
     return (
       <div className="basket-section">
-        <h2 className="section-heading">
+        <h5 aria-level="2">
           <FormattedMessage
             id="payment.card.details.billing.information.heading"
             defaultMessage="Billing Information"
             description="The heading for the credit card details billing information form"
           />
-        </h2>
+        </h5>
 
         <div className="row">
           <div className="col-lg-6 form-group">

--- a/src/payment/CardHolderInformation.jsx
+++ b/src/payment/CardHolderInformation.jsx
@@ -40,14 +40,13 @@ export class CardHolderInformationComponent extends React.Component {
     const { submitting, showBulkEnrollmentFields } = this.props;
     return (
       <div className="basket-section">
-        <h2 className="section-heading">
+        <h5 aria-level="2">
           <FormattedMessage
             id="payment.card.holder.information.heading"
             defaultMessage="Card Holder Information"
             description="The heading for the credit card holder information form"
           />
-        </h2>
-
+        </h5>
         <div className="row">
           <div className="col-lg-6 form-group">
             <label htmlFor="firstName">

--- a/src/payment/CartSummary.jsx
+++ b/src/payment/CartSummary.jsx
@@ -11,13 +11,13 @@ import { ORDER_TYPES } from './data/constants';
 function CartSummary({ products, orderType }) {
   return (
     <div className="basket-section">
-      <h2 className="section-heading">
+      <h5 aria-level="2">
         <FormattedMessage
           id="payment.productlineitem.purchase.cart.heading"
           defaultMessage="In Your Cart"
           description="Heading of the cart in product details section"
         />
-      </h2>
+      </h5>
       <p>
         <FormattedMessage
           id="payment.productlineitem.purchase.cart.subheading"

--- a/src/payment/OrderSummary.jsx
+++ b/src/payment/OrderSummary.jsx
@@ -179,13 +179,13 @@ function OrderSummary({
       aria-live="polite"
       className="basket-section"
     >
-      <h2 id="summary-heading" className="section-heading">
+      <h5 id="summary-heading" aria-level="2">
         <FormattedMessage
           id="payment.order.details.heading"
           defaultMessage="Summary"
           description="The heading for the order summary table and coupon section of the basket"
         />
-      </h2>
+      </h5>
 
       {
         orderType === ORDER_TYPES.BULK_ENROLLMENT ? (

--- a/src/payment/PaymentMethodSelect.jsx
+++ b/src/payment/PaymentMethodSelect.jsx
@@ -11,13 +11,13 @@ import { PayPalButton } from './paypal';
 function PaymentMethodSelect({ intl, loading }) {
   return (
     <div className="basket-section">
-      <h2 className="section-heading">
+      <h5 aria-level="2">
         <FormattedMessage
           id="payment.select.payment.method.heading"
           defaultMessage="Select Payment Method"
           description="The heading for the payment type selection section"
         />
-      </h2>
+      </h5>
 
       <p className="d-flex ">
         <button className="payment-method-button active">

--- a/src/payment/ProductLineItem.jsx
+++ b/src/payment/ProductLineItem.jsx
@@ -40,7 +40,7 @@ class ProductLineItem extends React.PureComponent {
           </div>
         </div>
         <div className="col-7">
-          <h3 className="course-heading m-0">{title}</h3>
+          <h6 className="m-0" aria-level="3">{title}</h6>
           <p className="m-0">{this.renderCertificateType(certificateType)}</p>
         </div>
       </div>

--- a/src/payment/__snapshots__/PaymentPage.test.jsx.snap
+++ b/src/payment/__snapshots__/PaymentPage.test.jsx.snap
@@ -19,13 +19,13 @@ exports[`<PaymentPage /> Renders correctly in various states should render a fre
         <div
           className="basket-section"
         >
-          <h2
-            className="section-heading"
+          <h5
+            aria-level="2"
           >
             <span>
               In Your Cart
             </span>
-          </h2>
+          </h5>
           <p>
             <span>
               Your purchase contains the following:
@@ -50,11 +50,12 @@ exports[`<PaymentPage /> Renders correctly in various states should render a fre
             <div
               className="col-7"
             >
-              <h3
-                className="course-heading m-0"
+              <h6
+                aria-level="3"
+                className="m-0"
               >
                 Introduction to Happiness
-              </h3>
+              </h6>
               <p
                 className="m-0"
               >
@@ -71,14 +72,14 @@ exports[`<PaymentPage /> Renders correctly in various states should render a fre
           className="basket-section"
           role="region"
         >
-          <h2
-            className="section-heading"
+          <h5
+            aria-level="2"
             id="summary-heading"
           >
             <span>
               Summary
             </span>
-          </h2>
+          </h5>
           <div
             className="summary-row d-flex"
           >
@@ -171,11 +172,11 @@ exports[`<PaymentPage /> Renders correctly in various states should render a fre
         <div
           className="basket-section"
         >
-          <h2
-            className="section-heading"
+          <h5
+            aria-level="2"
           >
             Order Details
-          </h2>
+          </h5>
           <p>
             After you complete your order you will be automatically enrolled in the verified track of the course.
           </p>
@@ -289,13 +290,13 @@ exports[`<PaymentPage /> Renders correctly in various states should render all c
         <div
           className="basket-section"
         >
-          <h2
-            className="section-heading"
+          <h5
+            aria-level="2"
           >
             <span>
               In Your Cart
             </span>
-          </h2>
+          </h5>
           <p>
             <span>
               Your purchase contains the following:
@@ -320,11 +321,12 @@ exports[`<PaymentPage /> Renders correctly in various states should render all c
             <div
               className="col-7"
             >
-              <h3
-                className="course-heading m-0"
+              <h6
+                aria-level="3"
+                className="m-0"
               >
                 Introduction to Happiness
-              </h3>
+              </h6>
               <p
                 className="m-0"
               >
@@ -341,14 +343,14 @@ exports[`<PaymentPage /> Renders correctly in various states should render all c
           className="basket-section"
           role="region"
         >
-          <h2
-            className="section-heading"
+          <h5
+            aria-level="2"
             id="summary-heading"
           >
             <span>
               Summary
             </span>
-          </h2>
+          </h5>
           <div
             className="summary-row d-flex"
           >
@@ -448,11 +450,11 @@ exports[`<PaymentPage /> Renders correctly in various states should render all c
         <div
           className="basket-section"
         >
-          <h2
-            className="section-heading"
+          <h5
+            aria-level="2"
           >
             Order Details
-          </h2>
+          </h5>
           <p>
             After you complete your order you will be automatically enrolled in the verified track of the course.
           </p>
@@ -465,13 +467,13 @@ exports[`<PaymentPage /> Renders correctly in various states should render all c
       <div
         className="basket-section"
       >
-        <h2
-          className="section-heading"
+        <h5
+          aria-level="2"
         >
           <span>
             Select Payment Method
           </span>
-        </h2>
+        </h5>
         <p
           className="d-flex "
         >
@@ -502,13 +504,13 @@ exports[`<PaymentPage /> Renders correctly in various states should render all c
         <div
           className="basket-section"
         >
-          <h2
-            className="section-heading"
+          <h5
+            aria-level="2"
           >
             <span>
               Card Holder Information
             </span>
-          </h2>
+          </h5>
           <div
             className="row"
           >
@@ -1976,13 +1978,13 @@ exports[`<PaymentPage /> Renders correctly in various states should render all c
         <div
           className="basket-section"
         >
-          <h2
-            className="section-heading"
+          <h5
+            aria-level="2"
           >
             <span>
               Billing Information
             </span>
-          </h2>
+          </h5>
           <div
             className="row"
           >
@@ -2396,13 +2398,13 @@ exports[`<PaymentPage /> Renders correctly in various states should render its d
         <div
           className="basket-section"
         >
-          <h2
-            className="section-heading"
+          <h5
+            aria-level="2"
           >
             <span>
               In Your Cart
             </span>
-          </h2>
+          </h5>
           <p>
             <span>
               Your purchase contains the following:
@@ -2415,14 +2417,14 @@ exports[`<PaymentPage /> Renders correctly in various states should render its d
           className="basket-section"
           role="region"
         >
-          <h2
-            className="section-heading"
+          <h5
+            aria-level="2"
             id="summary-heading"
           >
             <span>
               Summary
             </span>
-          </h2>
+          </h5>
           <div
             className="summary-row d-flex"
           >
@@ -2458,13 +2460,13 @@ exports[`<PaymentPage /> Renders correctly in various states should render its d
       <div
         className="basket-section"
       >
-        <h2
-          className="section-heading"
+        <h5
+          aria-level="2"
         >
           <span>
             Select Payment Method
           </span>
-        </h2>
+        </h5>
         <p
           className="d-flex "
         >
@@ -2495,13 +2497,13 @@ exports[`<PaymentPage /> Renders correctly in various states should render its d
         <div
           className="basket-section"
         >
-          <h2
-            className="section-heading"
+          <h5
+            aria-level="2"
           >
             <span>
               Card Holder Information
             </span>
-          </h2>
+          </h5>
           <div
             className="row"
           >
@@ -3969,13 +3971,13 @@ exports[`<PaymentPage /> Renders correctly in various states should render its d
         <div
           className="basket-section"
         >
-          <h2
-            className="section-heading"
+          <h5
+            aria-level="2"
           >
             <span>
               Billing Information
             </span>
-          </h2>
+          </h5>
           <div
             className="row"
           >
@@ -4390,13 +4392,13 @@ exports[`<PaymentPage /> Renders correctly in various states should render its l
       <div
         className="basket-section"
       >
-        <h2
-          className="section-heading"
+        <h5
+          aria-level="2"
         >
           <span>
             Select Payment Method
           </span>
-        </h2>
+        </h5>
         <p
           className="d-flex "
         >
@@ -4427,13 +4429,13 @@ exports[`<PaymentPage /> Renders correctly in various states should render its l
         <div
           className="basket-section"
         >
-          <h2
-            className="section-heading"
+          <h5
+            aria-level="2"
           >
             <span>
               Card Holder Information
             </span>
-          </h2>
+          </h5>
           <div
             className="row"
           >
@@ -5901,13 +5903,13 @@ exports[`<PaymentPage /> Renders correctly in various states should render its l
         <div
           className="basket-section"
         >
-          <h2
-            className="section-heading"
+          <h5
+            aria-level="2"
           >
             <span>
               Billing Information
             </span>
-          </h2>
+          </h5>
           <div
             className="row"
           >
@@ -6267,13 +6269,13 @@ exports[`<PaymentPage /> Renders correctly in various states should render the b
         <div
           className="basket-section"
         >
-          <h2
-            className="section-heading"
+          <h5
+            aria-level="2"
           >
             <span>
               In Your Cart
             </span>
-          </h2>
+          </h5>
           <p>
             <span>
               Your purchase contains the following:
@@ -6298,11 +6300,12 @@ exports[`<PaymentPage /> Renders correctly in various states should render the b
             <div
               className="col-7"
             >
-              <h3
-                className="course-heading m-0"
+              <h6
+                aria-level="3"
+                className="m-0"
               >
                 Introduction to Happiness
-              </h3>
+              </h6>
               <p
                 className="m-0"
               >
@@ -6319,14 +6322,14 @@ exports[`<PaymentPage /> Renders correctly in various states should render the b
           className="basket-section"
           role="region"
         >
-          <h2
-            className="section-heading"
+          <h5
+            aria-level="2"
             id="summary-heading"
           >
             <span>
               Summary
             </span>
-          </h2>
+          </h5>
           <div
             className="summary-row d-flex"
           >
@@ -6426,11 +6429,11 @@ exports[`<PaymentPage /> Renders correctly in various states should render the b
         <div
           className="basket-section"
         >
-          <h2
-            className="section-heading"
+          <h5
+            aria-level="2"
           >
             Order Details
-          </h2>
+          </h5>
           <p>
             After you complete your order you will be automatically enrolled in the verified track of the course.
           </p>
@@ -6443,13 +6446,13 @@ exports[`<PaymentPage /> Renders correctly in various states should render the b
       <div
         className="basket-section"
       >
-        <h2
-          className="section-heading"
+        <h5
+          aria-level="2"
         >
           <span>
             Select Payment Method
           </span>
-        </h2>
+        </h5>
         <p
           className="d-flex "
         >
@@ -6480,13 +6483,13 @@ exports[`<PaymentPage /> Renders correctly in various states should render the b
         <div
           className="basket-section"
         >
-          <h2
-            className="section-heading"
+          <h5
+            aria-level="2"
           >
             <span>
               Card Holder Information
             </span>
-          </h2>
+          </h5>
           <div
             className="row"
           >
@@ -7954,13 +7957,13 @@ exports[`<PaymentPage /> Renders correctly in various states should render the b
         <div
           className="basket-section"
         >
-          <h2
-            className="section-heading"
+          <h5
+            aria-level="2"
           >
             <span>
               Billing Information
             </span>
-          </h2>
+          </h5>
           <div
             className="row"
           >
@@ -8325,13 +8328,13 @@ exports[`<PaymentPage /> Renders correctly in various states should successfully
         <div
           className="basket-section"
         >
-          <h2
-            className="section-heading"
+          <h5
+            aria-level="2"
           >
             <span>
               In Your Cart
             </span>
-          </h2>
+          </h5>
           <p>
             <span>
               Your purchase contains the following:
@@ -8356,11 +8359,12 @@ exports[`<PaymentPage /> Renders correctly in various states should successfully
             <div
               className="col-7"
             >
-              <h3
-                className="course-heading m-0"
+              <h6
+                aria-level="3"
+                className="m-0"
               >
                 Introduction to Happiness
-              </h3>
+              </h6>
               <p
                 className="m-0"
               >
@@ -8377,14 +8381,14 @@ exports[`<PaymentPage /> Renders correctly in various states should successfully
           className="basket-section"
           role="region"
         >
-          <h2
-            className="section-heading"
+          <h5
+            aria-level="2"
             id="summary-heading"
           >
             <span>
               Summary
             </span>
-          </h2>
+          </h5>
           <div
             className="summary-row d-flex"
           >
@@ -8415,11 +8419,11 @@ exports[`<PaymentPage /> Renders correctly in various states should successfully
         <div
           className="basket-section"
         >
-          <h2
-            className="section-heading"
+          <h5
+            aria-level="2"
           >
             Order Details
-          </h2>
+          </h5>
           <p>
             After you complete your order you will be automatically enrolled in the verified track of the course.
           </p>
@@ -8432,13 +8436,13 @@ exports[`<PaymentPage /> Renders correctly in various states should successfully
       <div
         className="basket-section"
       >
-        <h2
-          className="section-heading"
+        <h5
+          aria-level="2"
         >
           <span>
             Select Payment Method
           </span>
-        </h2>
+        </h5>
         <p
           className="d-flex "
         >
@@ -8469,13 +8473,13 @@ exports[`<PaymentPage /> Renders correctly in various states should successfully
         <div
           className="basket-section"
         >
-          <h2
-            className="section-heading"
+          <h5
+            aria-level="2"
           >
             <span>
               Card Holder Information
             </span>
-          </h2>
+          </h5>
           <div
             className="row"
           >
@@ -9943,13 +9947,13 @@ exports[`<PaymentPage /> Renders correctly in various states should successfully
         <div
           className="basket-section"
         >
-          <h2
-            className="section-heading"
+          <h5
+            aria-level="2"
           >
             <span>
               Billing Information
             </span>
-          </h2>
+          </h5>
           <div
             className="row"
           >
@@ -10315,11 +10319,12 @@ exports[`<ProductLineItem /> Rendering should render the product details 1`] = `
   <div
     className="col-7"
   >
-    <h3
-      className="course-heading m-0"
+    <h6
+      aria-level="3"
+      className="m-0"
     >
       Introduction to Happiness
-    </h3>
+    </h6>
     <p
       className="m-0"
     >
@@ -10351,11 +10356,12 @@ exports[`<ProductLineItem /> Rendering should render the product details for aud
   <div
     className="col-7"
   >
-    <h3
-      className="course-heading m-0"
+    <h6
+      aria-level="3"
+      className="m-0"
     >
       Introduction to Happiness
-    </h3>
+    </h6>
     <p
       className="m-0"
     />
@@ -10383,11 +10389,12 @@ exports[`<ProductLineItem /> Rendering should render the product details for hon
   <div
     className="col-7"
   >
-    <h3
-      className="course-heading m-0"
+    <h6
+      aria-level="3"
+      className="m-0"
     >
       Introduction to Happiness
-    </h3>
+    </h6>
     <p
       className="m-0"
     />
@@ -10415,11 +10422,12 @@ exports[`<ProductLineItem /> Rendering should render the product details for no-
   <div
     className="col-7"
   >
-    <h3
-      className="course-heading m-0"
+    <h6
+      aria-level="3"
+      className="m-0"
     >
       Introduction to Happiness
-    </h3>
+    </h6>
     <p
       className="m-0"
     >
@@ -10451,11 +10459,12 @@ exports[`<ProductLineItem /> Rendering should render the product details for pro
   <div
     className="col-7"
   >
-    <h3
-      className="course-heading m-0"
+    <h6
+      aria-level="3"
+      className="m-0"
     >
       Introduction to Happiness
-    </h3>
+    </h6>
     <p
       className="m-0"
     >
@@ -10487,11 +10496,12 @@ exports[`<ProductLineItem /> Rendering should render the product details for unk
   <div
     className="col-7"
   >
-    <h3
-      className="course-heading m-0"
+    <h6
+      aria-level="3"
+      className="m-0"
     >
       Introduction to Happiness
-    </h3>
+    </h6>
     <p
       className="m-0"
     />
@@ -10519,11 +10529,12 @@ exports[`<ProductLineItem /> Rendering should render the product details for ver
   <div
     className="col-7"
   >
-    <h3
-      className="course-heading m-0"
+    <h6
+      aria-level="3"
+      className="m-0"
     >
       Introduction to Happiness
-    </h3>
+    </h6>
     <p
       className="m-0"
     >

--- a/src/payment/_style.scss
+++ b/src/payment/_style.scss
@@ -30,14 +30,8 @@
   .basket-section {
     @extend .mb-5;
   }
-  .section-heading {
-    @extend .h5;
-  }
   .summary-row {
     margin-bottom: map-get($spacers, 3);
-  }
-  .course-heading {
-    @extend .h6;
   }
   .summary-row {
     margin-bottom: map-get($spacers, 3);
@@ -87,7 +81,7 @@
   }
 
   .skeleton-pulse {
-    animation: skeleton-pulse 2s infinite both; 
+    animation: skeleton-pulse 2s infinite both;
   }
   .skeleton {
     background-color: rgba(0,0,0, .1);

--- a/src/payment/order-details/OrderDetails.jsx
+++ b/src/payment/order-details/OrderDetails.jsx
@@ -93,7 +93,7 @@ class OrderDetails extends Component {
           defaultMessage="Order Details"
           description="The heading for details about an order"
         >
-          {text => <h2 className="section-heading">{text}</h2>}
+          {text => <h5 aria-level="2">{text}</h5>}
         </FormattedMessage>
         {this.renderMessage()}
       </div>

--- a/src/payment/order-details/__snapshots__/OrderDetails.test.jsx.snap
+++ b/src/payment/order-details/__snapshots__/OrderDetails.test.jsx.snap
@@ -4,11 +4,11 @@ exports[`OrderDetails should render course entitlement product message 1`] = `
 <div
   className="basket-section"
 >
-  <h2
-    className="section-heading"
+  <h5
+    aria-level="2"
   >
     Order Details
-  </h2>
+  </h5>
   <p>
     After you complete your order you will be able to select course dates from your dashboard.
   </p>
@@ -19,11 +19,11 @@ exports[`OrderDetails should render credit seat message 1`] = `
 <div
   className="basket-section"
 >
-  <h2
-    className="section-heading"
+  <h5
+    aria-level="2"
   >
     Order Details
-  </h2>
+  </h5>
   <p>
     After you complete your order you will receive credit for your course.
   </p>
@@ -34,11 +34,11 @@ exports[`OrderDetails should render enrollment code product message 1`] = `
 <div
   className="basket-section"
 >
-  <h2
-    className="section-heading"
+  <h5
+    aria-level="2"
   >
     Order Details
-  </h2>
+  </h5>
   <p>
     By purchasing, you and your organization agree to the following terms:
   </p>
@@ -72,11 +72,11 @@ exports[`OrderDetails should render seat message 1`] = `
 <div
   className="basket-section"
 >
-  <h2
-    className="section-heading"
+  <h5
+    aria-level="2"
   >
     Order Details
-  </h2>
+  </h5>
   <p>
     After you complete your order you will be automatically enrolled in the course.
   </p>
@@ -87,11 +87,11 @@ exports[`OrderDetails should render verified seat message 1`] = `
 <div
   className="basket-section"
 >
-  <h2
-    className="section-heading"
+  <h5
+    aria-level="2"
   >
     Order Details
-  </h2>
+  </h5>
   <p>
     After you complete your order you will be automatically enrolled in the verified track of the course.
   </p>


### PR DESCRIPTION
For a11y, added `aria-level` to headings instead of changing the heading size with CSS. 
[ARCH-963](https://openedx.atlassian.net/browse/ARCH-963).