### PR TITLE
fix(prices): fix display of absolute value coupons

### DIFF
--- a/src/payment/coupon/CouponForm.jsx
+++ b/src/payment/coupon/CouponForm.jsx
@@ -96,19 +96,19 @@ export class CouponForm extends Component {
 
     if (benefitType === 'Absolute') {
       return (
-        <FormattedMessage
-          id="payment.coupon.benefit.absolute"
-          defaultMessage="Coupon {code} applied for {amount} off"
-          description="A coupon has been applied for a fixed currency discount, like $10.  Currency symbol will already be provided."
-          values={{
-            code,
-            amount: (
-              <LocalizedPrice amount={benefitValue} />
-            ),
-          }}
-        >
-          {renderMuted}
-        </FormattedMessage>);
+        <span className="text-muted">
+          <FormattedMessage
+            id="payment.coupon.benefit.absolute"
+            defaultMessage="Coupon {code} applied for {amount} off"
+            description="A coupon has been applied for a fixed currency discount, like $10.  Currency symbol will already be provided."
+            values={{
+              code,
+              amount: (
+                <LocalizedPrice amount={benefitValue} />
+              ),
+            }}
+          />
+        </span>);
     }
 
     if (benefitType === 'Percentage') {


### PR DESCRIPTION
The style of FormattedMessage that takes a child function can only handle text arguments to that function, not elements.