### PR TITLE
fix: add parameter to apple pay start session

### DIFF
--- a/src/payment/apple-pay/service.js
+++ b/src/payment/apple-pay/service.js
@@ -79,7 +79,10 @@ export const performApplePayPayment = ({
   applePaySession.onvalidatemerchant = (event) => {
     console.log('Validating merchant...');
 
-    const postData = { url: event.validationURL };
+    const postData = {
+      url: event.validationURL,
+      is_payment_microfrontend: true,
+    };
 
     return apiClient.post(config.APPLE_PAY_START_SESSION_URL, postData)
       .then((response) => {

--- a/src/payment/apple-pay/service.test.js
+++ b/src/payment/apple-pay/service.test.js
@@ -90,7 +90,7 @@ describe('Perform Apple Pay Payment', () => {
 
     expect(apiClient.post).toHaveBeenCalledWith(
       config.APPLE_PAY_START_SESSION_URL,
-      { url: validateEvent.validationURL },
+      { url: validateEvent.validationURL, is_payment_microfrontend: true },
     );
 
     return requestPromise.finally(() => {


### PR DESCRIPTION
ARCH-952 Add a flag to the start session request to allow the backend to differentiate between start session requests coming from the legacy page and this new microfrontend