### PR TITLE
feature(prices): move localized currency disclaimer closer to prices

### DIFF
--- a/src/payment/PaymentPage.jsx
+++ b/src/payment/PaymentPage.jsx
@@ -16,7 +16,6 @@ import { paymentSelector } from './data/selectors';
 import { PageLoading } from '../common';
 import OrderSummary from './order-summary';
 import OrderDetails from './order-details';
-import CurrencyDisclaimer from './CurrencyDisclaimer';
 import PaymentForm from './PaymentForm';
 import PlaceOrderButton from './PlaceOrderButton';
 import PaymentMethodSelect from './PaymentMethodSelect';
@@ -86,7 +85,6 @@ class PaymentPage extends React.Component {
 
   renderBasket() {
     const {
-      isCurrencyConverted,
       isFreeBasket,
       loading,
     } = this.props;
@@ -120,7 +118,6 @@ class PaymentPage extends React.Component {
               <CartSummary />
               <OrderSummary />
               <OrderDetails />
-              {isCurrencyConverted ? <CurrencyDisclaimer /> : null}
             </div>
           )}
         </section>
@@ -172,7 +169,6 @@ PaymentPage.propTypes = {
   intl: intlShape.isRequired,
   isFreeBasket: PropTypes.bool,
   isEmpty: PropTypes.bool,
-  isCurrencyConverted: PropTypes.bool,
   loaded: PropTypes.bool,
   loading: PropTypes.bool,
   dashboardURL: PropTypes.string.isRequired,
@@ -185,7 +181,6 @@ PaymentPage.defaultProps = {
   loaded: false,
   loading: false,
   isEmpty: false,
-  isCurrencyConverted: false,
 };
 
 export default connect(

--- a/src/payment/data/selectors.js
+++ b/src/payment/data/selectors.js
@@ -23,17 +23,24 @@ export const currencyDisclaimerSelector = state => ({
   actualAmount: state[storeName].basket.orderTotal,
 });
 
+export const orderSummarySelector = createSelector(
+  basketSelector,
+  localizedCurrencySelector,
+  (basket, currency) => ({
+    ...basket,
+    isCurrencyConverted: currency.showAsLocalizedCurrency,
+  }),
+);
+
 export const paymentSelector = createSelector(
   basketSelector,
   configurationSelector,
-  localizedCurrencySelector,
-  (basket, configuration, currency) => ({
+  (basket, configuration) => ({
     ...basket,
     dashboardURL: configuration.LMS_BASE_URL,
     supportURL: configuration.SUPPORT_URL,
     ecommerceURL: configuration.ECOMMERCE_BASE_URL,
     isEmpty: basket.loaded && (!basket.products || basket.products.length === 0),
-    isCurrencyConverted: currency.showAsLocalizedCurrency,
   }),
 );
 

--- a/src/payment/order-summary/CurrencyDisclaimer.jsx
+++ b/src/payment/order-summary/CurrencyDisclaimer.jsx
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { FormattedMessage, FormattedNumber, injectIntl } from '@edx/frontend-i18n';
 
-import { currencyDisclaimerSelector } from './data/selectors';
+import { currencyDisclaimerSelector } from '../data/selectors';
 
 function CurrencyDisclaimer(props) {
   return (
-    <div className="text-muted">
+    <div className="text-muted font-italic">
       <FormattedMessage
         id="payment.currency.disclaimer"
         defaultMessage="* This total contains an approximate conversion. You will be charged {actualAmount} {actualCurrencyCode}."

--- a/src/payment/order-summary/OrderSummary.jsx
+++ b/src/payment/order-summary/OrderSummary.jsx
@@ -4,12 +4,13 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { FormattedMessage } from '@edx/frontend-i18n';
 
-import { basketSelector } from '../data/selectors';
+import { orderSummarySelector } from '../data/selectors';
 import BulkOrderSummaryTable from './BulkOrderSummaryTable';
 import SummaryTable from './SummaryTable';
 import TotalTable from './TotalTable';
 import CouponForm from './CouponForm';
 import Offers from './Offers';
+import CurrencyDisclaimer from './CurrencyDisclaimer';
 
 import { ORDER_TYPES } from '../data/constants';
 
@@ -23,6 +24,7 @@ function OrderSummary({
   offers,
   orderTotal,
   showCouponForm,
+  isCurrencyConverted,
 }) {
   return (
     <div
@@ -54,11 +56,14 @@ function OrderSummary({
       {showCouponForm ? <CouponForm /> : null}
 
       <TotalTable total={orderTotal} />
+
+      {isCurrencyConverted ? <CurrencyDisclaimer /> : null}
     </div>
   );
 }
 
 OrderSummary.propTypes = {
+  isCurrencyConverted: PropTypes.bool,
   showCouponForm: PropTypes.bool,
   orderType: PropTypes.oneOf(Object.values(ORDER_TYPES)),
   orderTotal: PropTypes.number,
@@ -74,6 +79,7 @@ OrderSummary.propTypes = {
 };
 
 OrderSummary.defaultProps = {
+  isCurrencyConverted: false,
   showCouponForm: false,
   orderType: ORDER_TYPES.SEAT,
   orderTotal: undefined,
@@ -84,4 +90,4 @@ OrderSummary.defaultProps = {
   offers: [],
 };
 
-export default connect(basketSelector)(OrderSummary);
+export default connect(orderSummarySelector)(OrderSummary);


### PR DESCRIPTION
We thought the message about currency conversions being estimates would make more sense closer to the actual prices.

Also italicized the message to match the legacy page.

<img width="528" alt="moved disclaimer higher" src="https://user-images.githubusercontent.com/45690905/62076096-cf636b00-b214-11e9-8eeb-e9b9c0e155ec.png">