### PR TITLE
fix: set basket data on failure

### DIFF
--- a/src/payment/utils/handleBasketApiError.js
+++ b/src/payment/utils/handleBasketApiError.js
@@ -12,7 +12,7 @@ export default function (requestError) {
     processedError.fieldErrors = errorWithMessages.fieldErrors;
 
     if (requestError.response.data) {
-      processedError.basketData = transformResults(requestError.response.data);
+      processedError.basket = transformResults(requestError.response.data);
     }
 
     throw processedError;


### PR DESCRIPTION
Basket data was not properly handled on error. Now if an api call returns an error with data we will populate the app state with it. Partially fixes ARCH-1088.

<img width="1431" alt="Screen Shot 2019-07-31 at 10 26 22 AM" src="https://user-images.githubusercontent.com/1615421/62220210-add1c300-b37d-11e9-8617-ed41d51194a5.png">