### PR TITLE
Remove codecov and coveralls from Travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,3 @@ script:
   - npm run test
   - npm run build
   - npm run is-es5
-after_success:
-  - npm run coveralls
-  - codecov


### PR DESCRIPTION
We aren’t using coveralls for this repo, and we want to let Github manage our usage of codecov.  Currently our codecov config is failing our builds in Travis, causing the transifex jenkins jobs to fail downstream.  This PR should clear this up.