### PR TITLE
Use an ‘auto’ target for patch coverage.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,4 @@ script:
   - npm run build
   - npm run is-es5
 after_success:
-  - npm run coveralls
   - codecov

--- a/README.rst
+++ b/README.rst
@@ -154,13 +154,13 @@ described below:
 - Navigate to `https://local.stage.edx.org:1998 <https://local.stage.edx.org:1998>`_. You will see a warning that this page is unsecured because there is no valid SSL certificate. Proceed past this screen by clicking the "Advanced" button on the bottom left and then click the revealed link:
   "Proceed to local.stage.edx.org (unsafe)".
 
-.. |Build Status| image:: https://api.travis-ci.org/edx/frontend-app-ecommerce.svg?branch=master
-   :target: https://travis-ci.org/edx/frontend-app-ecommerce
-.. |Coveralls| image:: https://img.shields.io/coveralls/edx/frontend-app-ecommerce.svg?branch=master
-   :target: https://coveralls.io/github/edx/frontend-app-ecommerce
-.. |npm_version| image:: https://img.shields.io/npm/v/@edx/frontend-app-ecommerce.svg
-   :target: @edx/frontend-app-ecommerce
-.. |npm_downloads| image:: https://img.shields.io/npm/dt/@edx/frontend-app-ecommerce.svg
-   :target: @edx/frontend-app-ecommerce
-.. |license| image:: https://img.shields.io/npm/l/@edx/frontend-app-ecommerce.svg
-   :target: @edx/frontend-app-ecommerce
+.. |Build Status| image:: https://api.travis-ci.org/edx/frontend-app-payment.svg?branch=master
+   :target: https://travis-ci.org/edx/frontend-app-payment
+.. |Coveralls| image:: https://img.shields.io/coveralls/edx/frontend-app-payment.svg?branch=master
+   :target: https://coveralls.io/github/edx/frontend-app-payment
+.. |npm_version| image:: https://img.shields.io/npm/v/@edx/frontend-app-payment.svg
+   :target: @edx/frontend-app-payment
+.. |npm_downloads| image:: https://img.shields.io/npm/dt/@edx/frontend-app-payment.svg
+   :target: @edx/frontend-app-payment
+.. |license| image:: https://img.shields.io/npm/l/@edx/frontend-app-payment.svg
+   :target: @edx/frontend-app-payment

--- a/README.rst
+++ b/README.rst
@@ -156,11 +156,7 @@ described below:
 
 .. |Build Status| image:: https://api.travis-ci.org/edx/frontend-app-payment.svg?branch=master
    :target: https://travis-ci.org/edx/frontend-app-payment
-.. |Coveralls| image:: https://img.shields.io/coveralls/edx/frontend-app-payment.svg?branch=master
-   :target: https://coveralls.io/github/edx/frontend-app-payment
-.. |npm_version| image:: https://img.shields.io/npm/v/@edx/frontend-app-payment.svg
-   :target: @edx/frontend-app-payment
-.. |npm_downloads| image:: https://img.shields.io/npm/dt/@edx/frontend-app-payment.svg
-   :target: @edx/frontend-app-payment
+.. |Codecov| image:: https://codecov.io/gh/edx/frontend-app-payment/branch/master/graph/badge.svg
+   :target: https://codecov.io/gh/edx/frontend-app-payment
 .. |license| image:: https://img.shields.io/npm/l/@edx/frontend-app-payment.svg
    :target: @edx/frontend-app-payment

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,5 +6,5 @@ coverage:
         threshold: 0%
     patch:
       default:
-        target: 100%
+        target: auto
         threshold: 0%

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,7 @@ coverage:
   status:
     project:
       default:
-        target: 100%
+        target: auto
         threshold: 0%
     patch:
       default:


### PR DESCRIPTION
- Makes it so our coverage can only go up or stay the same.
- Removes coveralls - we're not using it for this repo
- Fixes our badges and adds one for codecov (I hope)

