### PR TITLE
fix: catch errors when starting an apple pay session

### DIFF
--- a/src/payment/apple-pay/ApplePayButton.jsx
+++ b/src/payment/apple-pay/ApplePayButton.jsx
@@ -2,15 +2,24 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { sendTrackEvent } from '@edx/frontend-analytics';
+import { logError } from '@edx/frontend-logging';
 import { performApplePayPayment } from './service';
 
 
 export default class ApplePayButton extends React.Component {
   constructor(props) {
     super(props);
+    let canMakePayments = false;
+
+    try {
+      canMakePayments = global.ApplePaySession && global.ApplePaySession.canMakePayments();
+    } catch (error) {
+      // We are likely on localhost without ssl
+      logError(error);
+    }
 
     this.state = {
-      canMakePayments: global.ApplePaySession && global.ApplePaySession.canMakePayments(),
+      canMakePayments,
     };
   }
 


### PR DESCRIPTION
This allows local development on http://localhost in Safari. Without catching errors the page would break.