### PR TITLE
fix: keep buttons locks on success

### DIFF
--- a/src/payment/data/reducers.js
+++ b/src/payment/data/reducers.js
@@ -29,7 +29,11 @@ const basket = (state = basketInitialState, action = null) => {
       submitting: true,
       paymentMethod: action.payload.method,
     };
-    case submitPayment.FULFILL: return { ...state, submitting: false, paymentMethod: undefined };
+    case submitPayment.FAILURE: return {
+      ...state,
+      submitting: false,
+      paymentMethod: undefined,
+    };
 
     case fetchBasket.TRIGGER: return { ...state, loading: true };
     case fetchBasket.SUCCESS: return { ...state, data: action.payload };


### PR DESCRIPTION
One success buttons will no longer be clickable in the time before the redirect takes hold