### PR TITLE
fix: handling of aborted transactions

### DIFF
--- a/src/payment/data/reducers.js
+++ b/src/payment/data/reducers.js
@@ -16,6 +16,7 @@ const basketInitialState = {
   loading: true,
   loaded: false,
   submitting: false,
+  redirect: false,
   products: [],
 };
 
@@ -23,11 +24,14 @@ const basket = (state = basketInitialState, action = null) => {
   switch (action.type) {
     case BASKET_DATA_RECEIVED: return { ...state, ...action.payload };
 
-    // For submission, we only really need to know whether it's actively submitting or not.
     case submitPayment.TRIGGER: return {
       ...state,
       submitting: true,
       paymentMethod: action.payload.method,
+    };
+    case submitPayment.SUCCESS: return {
+      ...state,
+      redirect: true,
     };
     case submitPayment.FULFILL: return {
       ...state,

--- a/src/payment/data/reducers.js
+++ b/src/payment/data/reducers.js
@@ -29,7 +29,7 @@ const basket = (state = basketInitialState, action = null) => {
       submitting: true,
       paymentMethod: action.payload.method,
     };
-    case submitPayment.FAILURE: return {
+    case submitPayment.FULFILL: return {
       ...state,
       submitting: false,
       paymentMethod: undefined,

--- a/src/payment/data/sagas.js
+++ b/src/payment/data/sagas.js
@@ -121,7 +121,7 @@ export function* handleSubmitPayment({ payload }) {
       }
     }
 
-    // Usually, fulfill this would be in a finally{ } block
+    // Usually, submitPayment.fulfill() would be in a finally{ } block
     // but on payment submission we are redirecting to the receipt
     // page and want to keep the basket in the submitting state
     // during that time.

--- a/src/payment/data/sagas.js
+++ b/src/payment/data/sagas.js
@@ -106,7 +106,7 @@ export function* handleSubmitPayment({ payload }) {
     yield put(submitPayment.success(result));
   } catch (error) {
     // Do not handle errors on user aborted actions
-    if (error.aborted !== true) {
+    if (!error.aborted) {
       yield put(submitPayment.failure(error));
       if (error.code) {
         // Client side generated errors are simple error objects and

--- a/src/payment/data/sagas.js
+++ b/src/payment/data/sagas.js
@@ -120,7 +120,11 @@ export function* handleSubmitPayment({ payload }) {
         yield put(basketDataReceived(error.basket));
       }
     }
-  } finally {
+
+    // Usually, fulfill this would be in a finally{ } block
+    // but on payment submission we are redirecting to the receipt
+    // page and want to keep the basket in the submitting state
+    // during that time.
     yield put(submitPayment.fulfill());
   }
 }

--- a/src/payment/data/sagas.js
+++ b/src/payment/data/sagas.js
@@ -105,9 +105,8 @@ export function* handleSubmitPayment({ payload }) {
     const result = yield call(paymentMethodCheckout, basket, paymentArgs);
     yield put(submitPayment.success(result));
   } catch (error) {
-    if (error.aborted === true) {
-      // This an a user aborted action, do nothing
-    } else {
+    // Do not handle errors on user aborted actions
+    if (error.aborted !== true) {
       yield put(submitPayment.failure(error));
       if (error.code) {
         // Client side generated errors are simple error objects and
@@ -120,11 +119,7 @@ export function* handleSubmitPayment({ payload }) {
         yield put(basketDataReceived(error.basket));
       }
     }
-
-    // Usually, submitPayment.fulfill() would be in a finally{ } block
-    // but on payment submission we are redirecting to the receipt
-    // page and want to keep the basket in the submitting state
-    // during that time.
+  } finally {
     yield put(submitPayment.fulfill());
   }
 }


### PR DESCRIPTION
Aborted transactions no longer lock the page in submitting state if they are aborted.