### PR TITLE
fix: update is basket processing state

### DIFF
--- a/src/payment/data/reducers.js
+++ b/src/payment/data/reducers.js
@@ -26,8 +26,12 @@ const basket = (state = basketInitialState, action = null) => {
 
     case submitPayment.TRIGGER: return {
       ...state,
-      submitting: true,
       paymentMethod: action.payload.method,
+    };
+    case submitPayment.REQUEST: return {
+      ...state,
+      submitting: true,
+      isBasketProcessing: true,
     };
     case submitPayment.SUCCESS: return {
       ...state,
@@ -36,6 +40,7 @@ const basket = (state = basketInitialState, action = null) => {
     case submitPayment.FULFILL: return {
       ...state,
       submitting: false,
+      isBasketProcessing: false,
       paymentMethod: undefined,
     };
 
@@ -44,20 +49,20 @@ const basket = (state = basketInitialState, action = null) => {
     case fetchBasket.FAILURE: return { ...state, error: action.payload };
     case fetchBasket.FULFILL: return { ...state, loading: false, loaded: true };
 
-    case addCoupon.TRIGGER: return { ...state, isCouponProcessing: true };
+    case addCoupon.REQUEST: return { ...state, isBasketProcessing: true };
     case addCoupon.SUCCESS: return { ...state, couponData: action.payload };
     case addCoupon.FAILURE: return { ...state, couponError: action.payload };
-    case addCoupon.FULFILL: return { ...state, isCouponProcessing: false };
+    case addCoupon.FULFILL: return { ...state, isBasketProcessing: false };
 
-    case removeCoupon.TRIGGER: return { ...state, isCouponProcessing: true };
+    case removeCoupon.REQUEST: return { ...state, isBasketProcessing: true };
     case removeCoupon.SUCCESS: return { ...state, couponData: action.payload };
     case removeCoupon.FAILURE: return { ...state, couponError: action.payload };
-    case removeCoupon.FULFILL: return { ...state, isCouponProcessing: false };
+    case removeCoupon.FULFILL: return { ...state, isBasketProcessing: false };
 
-    case updateQuantity.TRIGGER: return { ...state, isQuantityProcessing: true };
+    case updateQuantity.REQUEST: return { ...state, isBasketProcessing: true };
     case updateQuantity.SUCCESS: return { ...state, quantityData: action.payload };
     case updateQuantity.FAILURE: return { ...state, quantityError: action.payload };
-    case updateQuantity.FULFILL: return { ...state, isQuantityProcessing: false };
+    case updateQuantity.FULFILL: return { ...state, isBasketProcessing: false };
 
     default:
       return state;

--- a/src/payment/data/sagas.js
+++ b/src/payment/data/sagas.js
@@ -24,6 +24,11 @@ export const paymentMethods = {
   'apple-pay': checkoutApplePay,
 };
 
+
+function* isBasketProcessing() {
+  return yield select(state => state.payment.basket.isBasketProcessing);
+}
+
 export function* handleFetchBasket() {
   try {
     yield put(fetchBasket.request());
@@ -43,6 +48,8 @@ export function* handleFetchBasket() {
 }
 
 export function* handleAddCoupon({ payload }) {
+  if (yield isBasketProcessing()) return;
+
   try {
     yield put(addCoupon.request());
     const result = yield call(PaymentApiService.postCoupon, payload.code);
@@ -61,6 +68,8 @@ export function* handleAddCoupon({ payload }) {
 }
 
 export function* handleRemoveCoupon({ payload }) {
+  if (yield isBasketProcessing()) return;
+
   try {
     yield put(removeCoupon.request());
     const result = yield call(PaymentApiService.deleteCoupon, payload.code);
@@ -79,6 +88,8 @@ export function* handleRemoveCoupon({ payload }) {
 }
 
 export function* handleUpdateQuantity({ payload }) {
+  if (yield isBasketProcessing()) return;
+
   try {
     yield put(updateQuantity.request());
     const result = yield call(PaymentApiService.postQuantity, payload);
@@ -97,6 +108,8 @@ export function* handleUpdateQuantity({ payload }) {
 }
 
 export function* handleSubmitPayment({ payload }) {
+  if (yield isBasketProcessing()) return;
+
   const { method, ...paymentArgs } = payload;
   try {
     const paymentMethodCheckout = paymentMethods[method];

--- a/src/payment/data/selectors.js
+++ b/src/payment/data/selectors.js
@@ -17,18 +17,11 @@ export const localizedCurrencySelector = (state) => {
 
 export const basketSelector = state => state[storeName].basket;
 
-export const isBasketProcessingSelector = createSelector(
-  basketSelector,
-  basket => basket.isCouponProcessing || basket.isQuantityProcessing || basket.submitting,
-);
-
 export const cartSelector = createSelector(
   basketSelector,
-  isBasketProcessingSelector,
   localizedCurrencySelector,
-  (basket, isBasketProcessing, currency) => ({
+  (basket, currency) => ({
     ...basket,
-    isBasketProcessing,
     isCurrencyConverted: currency.showAsLocalizedCurrency,
   }),
 );
@@ -39,11 +32,10 @@ export const currencyDisclaimerSelector = state => ({
 
 export const updateQuantityFormSelector = createSelector(
   basketSelector,
-  isBasketProcessingSelector,
-  (basket, isBasketProcessing) => ({
+  basket => ({
     updateQuantity: basket.updateQuantity,
     summaryQuantity: basket.summaryQuantity,
-    isBasketProcessing,
+    isBasketProcessing: basket.isBasketProcessing,
   }),
 );
 
@@ -51,16 +43,14 @@ export const queryParametersSelector = state => state.queryParameters;
 
 export const paymentSelector = createSelector(
   basketSelector,
-  isBasketProcessingSelector,
   configurationSelector,
   queryParametersSelector,
-  (basket, isBasketProcessing, configuration, queryParameters) => {
+  (basket, configuration, queryParameters) => {
     const isCouponRedeemRedirect =
       queryParameters && queryParameters.coupon_redeem_redirect == 1; // eslint-disable-line eqeqeq
     return {
       ...basket,
       isCouponRedeemRedirect,
-      isBasketProcessing,
       dashboardURL: configuration.LMS_BASE_URL,
       supportURL: configuration.SUPPORT_URL,
       ecommerceURL: configuration.ECOMMERCE_BASE_URL,


### PR DESCRIPTION
Fixes doubling clicking errors described in ARCH-1109. Coupon and UpdateQuantity reducers now set isBasketProcessing directly rather than relying on derived state. Leverages the REQUEST action in redux saga routines to toggle isBasketProcessing. Sagas will noop if they are triggered when isBasketProcessing