### PR TITLE
Folding catchBasketError back into handleFetchBasket for simplicity.

### DIFF
--- a/src/payment/data/sagas.test.js
+++ b/src/payment/data/sagas.test.js
@@ -114,9 +114,7 @@ describe('saga tests', () => {
         ).toPromise();
       } catch (e) {} // eslint-disable-line no-empty
 
-      expect(dispatched).toEqual([
-        fetchBasket.fulfill(),
-      ]);
+      expect(dispatched).toEqual([]);
       expect(caughtErrors).toEqual([]);
     });
 


### PR DESCRIPTION
After a few merges/conflicts we were left in a place where we had a bit too much abstraction in the sagas.  This PR just simplifies that a bit and does a bit of formatting.

Lets us dispatch the fetchBasket.fulfill() action at the right time too.  
