### PR TITLE
fix: upgrade frontend-logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1053,6 +1053,13 @@
         "snakecase-keys": "^2.1.0",
         "universal-cookie": "^3.0.4",
         "url-parse": "^1.4.3"
+      },
+      "dependencies": {
+        "@edx/frontend-logging": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@edx/frontend-logging/-/frontend-logging-2.1.0.tgz",
+          "integrity": "sha512-IN0Bgh0/1Ax3TMPfZztqzdJchW4B5Px9PT4V9uu6TMj2Cj8el1CV3jrSA4Idg8C3CAkFZ/EHjmaFVCxgJ9aXVA=="
+        }
       }
     },
     "@edx/frontend-component-site-header": {
@@ -1091,9 +1098,9 @@
       }
     },
     "@edx/frontend-logging": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-logging/-/frontend-logging-2.1.0.tgz",
-      "integrity": "sha512-IN0Bgh0/1Ax3TMPfZztqzdJchW4B5Px9PT4V9uu6TMj2Cj8el1CV3jrSA4Idg8C3CAkFZ/EHjmaFVCxgJ9aXVA=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-logging/-/frontend-logging-3.0.1.tgz",
+      "integrity": "sha512-kRDsPbTUxNfZdnC4KN5HratS/7bkCYv/gyvUnBcuPbiONXwSuriNIVAKCepldvhg1DTwLqQMXh+Qw6vo2r048A=="
     },
     "@edx/paragon": {
       "version": "6.2.4",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@edx/frontend-auth": "5.3.5",
     "@edx/frontend-component-site-header": "2.5.0",
     "@edx/frontend-i18n": "3.0.2",
-    "@edx/frontend-logging": "2.1.0",
+    "@edx/frontend-logging": "^3.0.1",
     "@edx/paragon": "6.2.4",
     "@fortawesome/fontawesome-svg-core": "1.2.21",
     "@fortawesome/free-brands-svg-icons": "5.10.1",

--- a/src/common/serviceUtils.js
+++ b/src/common/serviceUtils.js
@@ -1,5 +1,5 @@
 import pick from 'lodash.pick';
-import { logAPIErrorResponse, logInfo } from '@edx/frontend-logging';
+import { logApiClientError, logInfo } from '@edx/frontend-logging';
 import { camelCaseObject } from './utils';
 
 
@@ -85,6 +85,6 @@ export function handleRequestError(error) {
   }
 
   // Other errors
-  logAPIErrorResponse(error);
+  logApiClientError(error);
   throw error;
 }

--- a/src/payment/payment-methods/apple-pay/service.js
+++ b/src/payment/payment-methods/apple-pay/service.js
@@ -1,5 +1,5 @@
 import pick from 'lodash.pick';
-import { logAPIErrorResponse } from '@edx/frontend-logging';
+import { logApiClientError } from '@edx/frontend-logging';
 import { applyConfiguration } from '../../../common/serviceUtils';
 
 let apiClient = null;
@@ -94,7 +94,7 @@ export function checkout(basket) {
         .catch((error) => {
           // eslint-disable-next-line no-param-reassign
           error.code = 'apple-pay-merchant-validation-failure';
-          logAPIErrorResponse(error, {
+          logApiClientError(error, {
             messagePrefix: 'Apple Pay Merchant Validation Failure',
             paymentMethod: 'Apple Pay',
             paymentErrorType: 'Merchant Validation',
@@ -118,7 +118,7 @@ export function checkout(basket) {
         .catch((error) => {
           // eslint-disable-next-line no-param-reassign
           error.code = 'apple-pay-authorization-failure';
-          logAPIErrorResponse(error, {
+          logApiClientError(error, {
             messagePrefix: 'Apple Pay Authorization Failure',
             paymentMethod: 'Apple Pay',
             paymentErrorType: 'Authorization',

--- a/src/payment/payment-methods/apple-pay/service.test.js
+++ b/src/payment/payment-methods/apple-pay/service.test.js
@@ -4,7 +4,7 @@ import {
 } from './service';
 
 jest.mock('@edx/frontend-logging', () => ({
-  logAPIErrorResponse: jest.fn(),
+  logApiClientError: jest.fn(),
 }));
 
 describe('Perform Apple Pay Payment', () => {

--- a/src/payment/payment-methods/cybersource/service.js
+++ b/src/payment/payment-methods/cybersource/service.js
@@ -1,6 +1,6 @@
 import formurlencoded from 'form-urlencoded';
 import pick from 'lodash.pick';
-import { logAPIErrorResponse } from '@edx/frontend-logging';
+import { logApiClientError } from '@edx/frontend-logging';
 
 import { applyConfiguration } from '../../../common/serviceUtils';
 import { generateAndSubmitForm } from '../../../common/utils';
@@ -35,7 +35,7 @@ export async function sdnCheck(basketId, firstName, lastName, city, country) {
       country,
     },
   ).catch((error) => {
-    logAPIErrorResponse(error, {
+    logApiClientError(error, {
       messagePrefix: 'SDN Check Error',
       paymentMethod: 'Cybersource',
       paymentErrorType: 'SDN Check',
@@ -97,7 +97,7 @@ export async function checkout(basket, { cardHolderInfo, cardDetails }) {
       },
     },
   ).catch((error) => {
-    logAPIErrorResponse(error, {
+    logApiClientError(error, {
       messagePrefix: 'Cybersource Submit Error',
       paymentMethod: 'Cybersource',
       paymentErrorType: 'Submit Error',

--- a/src/payment/payment-methods/cybersource/service.test.js
+++ b/src/payment/payment-methods/cybersource/service.test.js
@@ -8,11 +8,11 @@ jest.mock('../../../common/utils', () => ({
 }));
 
 jest.mock('@edx/frontend-logging', () => ({
-  logAPIErrorResponse: jest.fn(),
+  logApiClientError: jest.fn(),
 }));
 
 import { generateAndSubmitForm } from '../../../common/utils'; // eslint-disable-line import/first
-import { logAPIErrorResponse } from '@edx/frontend-logging'; // eslint-disable-line import/first
+import { logApiClientError } from '@edx/frontend-logging'; // eslint-disable-line import/first
 
 const config = {
   ECOMMERCE_BASE_URL: 'ecommerce.org',
@@ -130,7 +130,7 @@ describe('Cybersource Service', () => {
 
     return checkout(basket, formDetails)
       .catch(() => {
-        expect(logAPIErrorResponse)
+        expect(logApiClientError)
           .toHaveBeenCalledWith(sdnErrorResponse, {
             messagePrefix: 'SDN Check Error',
             paymentMethod: 'Cybersource',
@@ -156,7 +156,7 @@ describe('Cybersource Service', () => {
 
     return checkout(basket, formDetails)
       .catch(() => {
-        expect(logAPIErrorResponse)
+        expect(logApiClientError)
           .toHaveBeenCalledWith(errorResponse, {
             messagePrefix: 'Cybersource Submit Error',
             paymentMethod: 'Cybersource',

--- a/src/payment/payment-methods/paypal/service.js
+++ b/src/payment/payment-methods/paypal/service.js
@@ -1,5 +1,5 @@
 import pick from 'lodash.pick';
-import { logAPIErrorResponse } from '@edx/frontend-logging';
+import { logApiClientError } from '@edx/frontend-logging';
 
 import { applyConfiguration } from '../../../common/serviceUtils';
 import { generateAndSubmitForm } from '../../../common/utils';
@@ -34,7 +34,7 @@ export async function checkout(basket) {
       payment_processor: 'paypal',
     },
   ).catch((error) => {
-    logAPIErrorResponse(error, {
+    logApiClientError(error, {
       messagePrefix: 'PayPal Checkout Error',
       paymentMethod: 'PayPal',
       paymentErrorType: 'Checkout',

--- a/src/payment/payment-methods/paypal/service.test.js
+++ b/src/payment/payment-methods/paypal/service.test.js
@@ -8,11 +8,11 @@ jest.mock('../../../common/utils', () => ({
 }));
 
 jest.mock('@edx/frontend-logging', () => ({
-  logAPIErrorResponse: jest.fn(),
+  logApiClientError: jest.fn(),
 }));
 
 import { generateAndSubmitForm } from '../../../common/utils'; // eslint-disable-line import/first
-import { logAPIErrorResponse } from '@edx/frontend-logging'; // eslint-disable-line import/first
+import { logApiClientError } from '@edx/frontend-logging'; // eslint-disable-line import/first
 
 describe('Paypal Service', () => {
   const config = {
@@ -48,7 +48,7 @@ describe('Paypal Service', () => {
     }));
 
     return checkout(basket).catch(() => {
-      expect(logAPIErrorResponse)
+      expect(logApiClientError)
         .toHaveBeenCalledWith(errorResponse, {
           messagePrefix: 'PayPal Checkout Error',
           paymentMethod: 'PayPal',


### PR DESCRIPTION
Swap usage of logAPIErrorResponse with logApiClientError. Message prefixes will now be prepended to error messages in New Relic