### PR TITLE
ARCH-1148: fix: strip non-digits from card number

### DIFF
--- a/src/payment/checkout/payment-form/PaymentForm.test.jsx
+++ b/src/payment/checkout/payment-form/PaymentForm.test.jsx
@@ -191,7 +191,7 @@ describe('<PaymentForm />', () => {
         ['', '', `${currentMonth - 1}`, `${currentYear}`, { cardExpirationMonth: 'Card expired' }],
         ['41111', '', '', '', { cardNumber: 'Invalid card number' }],
         ['30569309025904', '', '', '', { cardNumber: 'Unsupported card type' }],
-        ['4111111111111111', '12345', '', '', { securityCode: 'Invalid security code' }],
+        ['4111-1111-1111-1111', '12345', '', '', { securityCode: 'Invalid security code' }],
       ];
 
       testData.forEach((testCaseData) => {

--- a/src/payment/payment-methods/cybersource/service.js
+++ b/src/payment/payment-methods/cybersource/service.js
@@ -92,6 +92,13 @@ function handleApiError(requestError) {
   }
 }
 
+// Strips spaces, hyphens, and any non-digit from a cardNumber
+function getCardNumberDigits(cardNumber) {
+  const numberPattern = /\d+/g;
+  const cardNumberDigitArray = cardNumber.match(numberPattern) || [];
+  return cardNumberDigitArray.join('');
+}
+
 /**
  * Checkout with Cybersource.
  *
@@ -173,7 +180,7 @@ export async function checkout(basket, { cardHolderInfo, cardDetails }) {
 
   const cybersourcePaymentParams = {
     ...data.form_fields,
-    card_number: cardNumber,
+    card_number: getCardNumberDigits(cardNumber),
     card_type: cardTypeId,
     card_cvn: securityCode,
     card_expiry_date: [cardExpirationMonth.padStart(2, '0'), cardExpirationYear].join('-'),

--- a/src/payment/payment-methods/cybersource/service.test.js
+++ b/src/payment/payment-methods/cybersource/service.test.js
@@ -34,7 +34,7 @@ describe('Cybersource Service', () => {
       organization: 'skunkworks',
     },
     cardDetails: {
-      cardNumber: '4111111111111111',
+      cardNumber: '4111-1111-1111-1111 ',
       cardTypeId: 'VISA??',
       securityCode: '123',
       cardExpirationMonth: '10',


### PR DESCRIPTION
Before submitting to CyberSource, strips non-digits (e.g. spaces,
hyphens, etc.) from the credit card number.

ARCH-1148