### PR TITLE
Temporarily disable apple pay

### DIFF
--- a/src/payment/checkout/Checkout.jsx
+++ b/src/payment/checkout/Checkout.jsx
@@ -13,7 +13,6 @@ import AcceptedCardLogos from './assets/accepted-card-logos.png';
 import PaymentForm from './payment-form/PaymentForm';
 import FreeCheckoutOrderButton from './FreeCheckoutOrderButton';
 import { PayPalButton } from '../payment-methods/paypal';
-import { ApplePayButton } from '../payment-methods/apple-pay';
 import { ORDER_TYPES } from '../data/constants';
 
 class Checkout extends React.Component {
@@ -125,11 +124,7 @@ class Checkout extends React.Component {
               isProcessing={payPalIsSubmitting}
             />
 
-            <ApplePayButton
-              onClick={this.handleSubmitApplePay}
-              className={classNames('payment-method-button', { 'skeleton-pulse': loading })}
-              disabled={submissionDisabled}
-            />
+            {/* Apple Pay temporarily disabled per REV-927  - https://github.com/edx/frontend-app-payment/pull/256 */}
           </p>
         </div>
 

--- a/src/payment/checkout/Checkout.test.jsx
+++ b/src/payment/checkout/Checkout.test.jsx
@@ -82,20 +82,7 @@ describe('<Checkout />', () => {
       expect(store.getActions().pop()).toEqual(submitPayment({ method: 'paypal' }));
     });
 
-    it('submits and tracks apple pay', () => {
-      const applePayButton = wrapper
-        .find('ApplePayButton')
-        .find('button')
-        .hostNodes();
-      applePayButton.simulate('click');
-
-      expect(sendTrackEvent).toHaveBeenCalledWith('edx.bi.ecommerce.basket.payment_selected', {
-        type: 'click',
-        category: 'checkout',
-        paymentMethod: 'Apple Pay',
-      });
-      expect(store.getActions().pop()).toEqual(submitPayment({ method: 'apple-pay' }));
-    });
+    // Apple Pay temporarily disabled per REV-927 - https://github.com/edx/frontend-app-payment/pull/256
 
     it('submits and tracks the payment form', () => {
       const formSubmitButton = wrapper.find('form button[type="submit"]').hostNodes();


### PR DESCRIPTION
This will accompany disabling the flag `enable_apple_pay` on stage and production ecommerce admin, as well as notifying support.
- Support have been notified that this will likely go out Monday, September 9

REV-927