### PR TITLE
[WIP] fix discount bug with payment error

### DIFF
--- a/src/payment/data/sagas.js
+++ b/src/payment/data/sagas.js
@@ -163,6 +163,7 @@ export function* handleSubmitPayment({ payload }) {
       }
 
       if (error.basket) {
+        yield call(handleDiscountCheck);
         yield put(basketDataReceived(error.basket));
       }
     }

--- a/src/payment/data/sagas.test.js
+++ b/src/payment/data/sagas.test.js
@@ -739,10 +739,6 @@ describe('saga tests', () => {
         submitPayment.request(),
         clearMessages(),
         addMessage('ohboy', null, null, 'error'),
-        basketDataReceived({
-          i: 'am',
-          a: 'basket',
-        }),
         basketProcessing(false),
         submitPayment.fulfill(),
       ]);
@@ -791,10 +787,6 @@ describe('saga tests', () => {
       addMessage(null, 'This is a field error!', null, 'error', 'field1'),
       stopSubmit('payment', {
         field1: 'This is a field error!',
-      }),
-      basketDataReceived({
-        i: 'am',
-        a: 'basket',
       }),
       basketProcessing(false),
       submitPayment.fulfill(),


### PR DESCRIPTION
issue: when a payment error happens and the basket page update the discount doesn't get reapplied. this causes the user to get charged the full amount, but then the receipt page shows they got charged the discounted amount

i don't think there is a way to test the fix locally so my suggestion for testing would be to 
merge, deploy to stage, modify local code so that an error on stage is possible, change flags on stage to direct everyone to mfe, make error purchase on stage? no sure if this will work  

if this doesn't work, then just retest successful purchases on stage, then deploy to prod, test payment errors and retest successful purchases and rollback if we find an issue 