### PR TITLE
Add some speedcurve events to payment page

### DIFF
--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -129,3 +129,10 @@ export function generateAndSubmitForm(url, params = {}) {
   global.document.body.appendChild(form);
   form.submit();
 }
+
+// Used for SpeedCurve performance tracking
+export function markPerformanceIfAble(markName) {
+  if (performance.mark) {
+    performance.mark(markName);
+  }
+}

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -6,7 +6,7 @@ import SiteHeader from '@edx/frontend-component-site-header';
 import { IntlProvider, injectIntl, intlShape, getLocale, getMessages } from '@edx/frontend-i18n';
 import { logInfo } from '@edx/frontend-logging';
 
-import { ErrorBoundary, fetchUserAccount } from '../common';
+import { ErrorBoundary, fetchUserAccount, utils } from '../common';
 import { ConnectedPaymentPage } from '../payment';
 import HeaderLogo from '../assets/logo.svg';
 import messages from './App.messages';
@@ -105,12 +105,29 @@ PageContent.defaultProps = {
 const IntlPageContent = injectIntl(PageContent);
 
 class App extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      hasPreviouslyRendered: false,
+    };
+  }
+
   componentDidMount() {
     const { username } = this.props;
     this.props.fetchUserAccount(username);
   }
 
   render() {
+    // Send performance event on initial render
+    if (!this.state.hasPreviouslyRendered) {
+      utils.markPerformanceIfAble('Payment app began painting');
+
+      this.setState({
+        hasPreviouslyRendered: true,
+      });
+    }
+
     return (
       <ErrorBoundary>
         <IntlProvider locale={getLocale()} messages={getMessages()}>

--- a/src/payment/cart/OrderSummary.jsx
+++ b/src/payment/cart/OrderSummary.jsx
@@ -2,24 +2,36 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from '@edx/frontend-i18n';
 
-function OrderSummary({ children }) {
-  return (
-    <div
-      role="region"
-      aria-labelledby="summary-heading"
-      aria-live="polite"
-      className="basket-section"
-    >
-      <h5 id="summary-heading" aria-level="2">
-        <FormattedMessage
-          id="payment.order.details.heading"
-          defaultMessage="Summary"
-          description="The heading for the order summary table and coupon section of the basket"
-        />
-      </h5>
-      {children}
-    </div>
-  );
+import { utils } from '../../common';
+
+class OrderSummary extends React.Component {
+  componentDidMount() {
+    utils.markPerformanceIfAble('Order Summary component rendered');
+  }
+
+  render() {
+    const {
+      children,
+    } = this.props;
+
+    return (
+      <div
+        role="region"
+        aria-labelledby="summary-heading"
+        aria-live="polite"
+        className="basket-section"
+      >
+        <h5 id="summary-heading" aria-level="2">
+          <FormattedMessage
+            id="payment.order.details.heading"
+            defaultMessage="Summary"
+            description="The heading for the order summary table and coupon section of the basket"
+          />
+        </h5>
+        {children}
+      </div>
+    );
+  }
 }
 
 OrderSummary.propTypes = {

--- a/src/payment/checkout/payment-form/PaymentForm.jsx
+++ b/src/payment/checkout/payment-form/PaymentForm.jsx
@@ -9,6 +9,7 @@ import CardDetails from './CardDetails';
 import CardHolderInformation from './CardHolderInformation';
 import getStates from './utils/countryStatesMap';
 import messages from './PaymentForm.messages';
+import { utils } from '../../../common';
 
 const CardValidator = require('../../../common/card-validator');
 
@@ -16,6 +17,16 @@ export class PaymentFormComponent extends React.Component {
   constructor(props) {
     super(props);
     this.formRef = React.createRef();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (
+      this.props.loading !== prevProps.loading
+      && !this.props.loading
+    ) {
+      // Send a SpeedCurve event when we stop loading for the first time
+      utils.markPerformanceIfAble('Payment form finished loading');
+    }
   }
 
   onSubmit = (values) => {


### PR DESCRIPTION
REV-984

Different types of events will be added later if this does not give us what we need.

Follows the basic idea of https://github.com/edx/edx-mktg/blob/4e3b18a6ad7e2a5b3a048d354f2fef56df0b474d/docroot/sites/all/themes/atedx/scripts/react/pages/privacy_policy/PrivacyPolicy.jsx#L11-#L18