### PR TITLE
Add speedcurve event for when PaymentForm mounts

### DIFF
--- a/src/payment/checkout/payment-form/PaymentForm.jsx
+++ b/src/payment/checkout/payment-form/PaymentForm.jsx
@@ -19,6 +19,10 @@ export class PaymentFormComponent extends React.Component {
     this.formRef = React.createRef();
   }
 
+  componentDidMount() {
+    utils.markPerformanceIfAble('Payment Form component rendered');
+  }
+
   componentDidUpdate(prevProps) {
     if (
       this.props.loading !== prevProps.loading


### PR DESCRIPTION
The payment form finishes loading at essentially the same time the
order summary mounts, so that doesn't tell us much about the timing
differences between the right and left sides of the page. Adding this
will give us a bit more info about when the payment form first becomes
visible.


**Payment form mount:**
<img width="893" alt="Screen Shot 2019-10-15 at 9 09 44 AM" src="https://user-images.githubusercontent.com/14864970/66834644-0bf95580-ef2c-11e9-8959-2a6a0aebeefd.png">
