### PR TITLE
fix: implement currency cookie detection as selector

### DIFF
--- a/src/payment/AlertCodeMessages.test.jsx
+++ b/src/payment/AlertCodeMessages.test.jsx
@@ -27,9 +27,7 @@ describe('EnrollmentCodeQuantityUpdated', () => {
     const component = (
       <IntlProvider locale="en">
         <Provider
-          store={mockStore({
-            payment: { currency: 'USD' },
-          })}
+          store={mockStore()}
         >
           <EnrollmentCodeQuantityUpdated values={{ quantity: 2, price: 100 }} />
         </Provider>

--- a/src/payment/PaymentPage.test.jsx
+++ b/src/payment/PaymentPage.test.jsx
@@ -9,6 +9,7 @@ import { Factory } from 'rosie';
 import { IntlProvider } from '@edx/frontend-i18n';
 import * as analytics from '@edx/frontend-analytics';
 import { fetchUserAccountSuccess } from '@edx/frontend-auth';
+import Cookies from 'universal-cookie';
 
 import './__factories__/basket.factory';
 import './__factories__/userAccount.factory';
@@ -18,6 +19,18 @@ import { fetchBasket, basketDataReceived } from './data/actions';
 import { transformResults } from './data/service';
 import { ENROLLMENT_CODE_PRODUCT_TYPE } from './cart/order-details';
 import { MESSAGE_TYPES, addMessage } from '../feedback';
+
+jest.mock('universal-cookie', () => {
+  class MockCookies {
+    static result = {};
+
+    get() {
+      return MockCookies.result;
+    }
+  }
+  return MockCookies;
+});
+
 
 // Mock language cookie
 Object.defineProperty(global.document, 'cookie', {
@@ -39,6 +52,7 @@ describe('<PaymentPage />', () => {
   describe('Renders correctly in various states', () => {
     beforeEach(() => {
       analytics.sendTrackingLogEvent = jest.fn();
+      Cookies.result = undefined;
     });
 
     it('should render its default (loading) state', () => {
@@ -71,16 +85,14 @@ describe('<PaymentPage />', () => {
     });
 
     it('should render the basket in a different currency', () => {
+      Cookies.result = {
+        code: 'MXN',
+        rate: 19.092733,
+      };
+
       store = createStore(
         createRootReducer(),
-        Object.assign({}, {
-          payment: {
-            currency: {
-              currencyCode: 'MXN',
-              conversionRate: 19.092733,
-            },
-          },
-        }),
+        {},
         applyMiddleware(thunkMiddleware),
       );
       const component = (

--- a/src/payment/cart/Cart.test.jsx
+++ b/src/payment/cart/Cart.test.jsx
@@ -5,6 +5,7 @@ import { IntlProvider } from '@edx/frontend-i18n';
 import { fetchUserAccountSuccess } from '@edx/frontend-auth';
 import { Factory } from 'rosie';
 import { createStore } from 'redux';
+import Cookies from 'universal-cookie';
 
 import '../__factories__/basket.factory';
 import '../__factories__/userAccount.factory';
@@ -13,6 +14,17 @@ import createRootReducer from '../../data/reducers';
 import { fetchBasket, basketDataReceived } from '../data/actions';
 import { transformResults } from '../data/service';
 
+jest.mock('universal-cookie', () => {
+  class MockCookies {
+    static result = {};
+
+    get() {
+      return MockCookies.result;
+    }
+  }
+  return MockCookies;
+});
+
 describe('<Cart />', () => {
   let store;
   let tree;
@@ -20,7 +32,7 @@ describe('<Cart />', () => {
 
   beforeEach(() => {
     userAccount = Factory.build('userAccount');
-
+    Cookies.result = undefined;
     store = createStore(createRootReducer(), {});
     store.dispatch(fetchUserAccountSuccess(userAccount));
 
@@ -77,16 +89,15 @@ describe('<Cart />', () => {
   });
 
   it('renders a cart in non USD currency', () => {
+    Cookies.result = {
+      code: 'MXN',
+      rate: 19.092733,
+    };
     // This test uses its own setup since we don't have actions to update currency.
     store = createStore(
       createRootReducer(),
       {
-        payment: {
-          currency: {
-            currencyCode: 'MXN',
-            conversionRate: 19.092733,
-          },
-        },
+        payment: {},
       },
     );
     const component = (

--- a/src/payment/cart/CouponForm.test.jsx
+++ b/src/payment/cart/CouponForm.test.jsx
@@ -22,7 +22,6 @@ const baseState = {
       coupons: [],
       isBasketProcessing: false,
     },
-    currency: {},
   },
 };
 

--- a/src/payment/cart/LocalizedPrice.test.jsx
+++ b/src/payment/cart/LocalizedPrice.test.jsx
@@ -3,8 +3,20 @@ import { Provider } from 'react-redux';
 import renderer from 'react-test-renderer';
 import configureMockStore from 'redux-mock-store';
 import { IntlProvider } from '@edx/frontend-i18n';
+import Cookies from 'universal-cookie';
 
 import LocalizedPrice from './LocalizedPrice';
+
+jest.mock('universal-cookie', () => {
+  class MockCookies {
+    static result = {};
+
+    get() {
+      return MockCookies.result;
+    }
+  }
+  return MockCookies;
+});
 
 jest.mock('@edx/frontend-logging', () => ({
   logError: jest.fn(),
@@ -24,15 +36,12 @@ describe('LocalizedPrice', () => {
           loading: false,
           products: [],
         },
-        currency: {
-          currencyCode: null,
-          conversionRate: 1,
-        },
       },
       i18n: {
         locale: 'en',
       },
     };
+    Cookies.result = undefined;
   });
 
   it('should render nothing by default', () => {
@@ -64,17 +73,14 @@ describe('LocalizedPrice', () => {
   });
 
   it('should render localized currency', () => {
+    Cookies.result = {
+      code: 'MXN',
+      rate: 19,
+    };
     const component = (
       <IntlProvider locale="en">
         <Provider
-          store={mockStore(Object.assign({}, state, {
-            payment: {
-              currency: {
-                currencyCode: 'MXN',
-                conversionRate: 19,
-              },
-            },
-          }))}
+          store={mockStore(Object.assign({}, state))}
         >
           <LocalizedPrice amount={10} />
         </Provider>

--- a/src/payment/cart/Offers.test.jsx
+++ b/src/payment/cart/Offers.test.jsx
@@ -8,7 +8,7 @@ import Offers from './Offers';
 
 const mockStore = configureMockStore();
 
-const baseState = { payment: { basket: {}, currency: {} } };
+const baseState = { payment: { basket: {} } };
 
 const renderWithProviders = children => renderer.create((
   <IntlProvider locale="en">

--- a/src/payment/cart/__snapshots__/LocalizedPrice.test.jsx.snap
+++ b/src/payment/cart/__snapshots__/LocalizedPrice.test.jsx.snap
@@ -11,6 +11,6 @@ exports[`LocalizedPrice should render localized currency 1`] = `
 
 exports[`LocalizedPrice should render unlocalized currency 1`] = `
 <span>
-  10
+  $10.00
 </span>
 `;

--- a/src/payment/data/__snapshots__/redux.test.js.snap
+++ b/src/payment/data/__snapshots__/redux.test.js.snap
@@ -10,7 +10,6 @@ Object {
     "redirect": false,
     "submitting": false,
   },
-  "currency": Object {},
 }
 `;
 
@@ -24,7 +23,6 @@ Object {
     "redirect": false,
     "submitting": false,
   },
-  "currency": Object {},
 }
 `;
 
@@ -38,6 +36,5 @@ Object {
     "redirect": false,
     "submitting": false,
   },
-  "currency": Object {},
 }
 `;

--- a/src/payment/data/reducers.js
+++ b/src/payment/data/reducers.js
@@ -1,6 +1,4 @@
-import { App } from '@edx/frontend-base';
 import { combineReducers } from 'redux';
-import Cookies from 'universal-cookie';
 
 import {
   BASKET_DATA_RECEIVED,
@@ -59,26 +57,8 @@ const basket = (state = basketInitialState, action = null) => {
   return state;
 };
 
-/* istanbul ignore next */
-function getCurrencyInitialState() {
-  const cookie = new Cookies().get(App.config.CURRENCY_COOKIE_NAME);
-
-  if (cookie && typeof cookie.code === 'string' && typeof cookie.rate === 'number') {
-    return {
-      currencyCode: cookie.code,
-      conversionRate: cookie.rate,
-    };
-  }
-  return {};
-}
-
-const currencyInitialState = getCurrencyInitialState();
-
-const currency = (state = currencyInitialState) => ({ ...state });
-
 const reducer = combineReducers({
   basket,
-  currency,
 });
 
 export default reducer;

--- a/src/payment/data/redux.test.js
+++ b/src/payment/data/redux.test.js
@@ -8,6 +8,18 @@ import {
   fetchBasket,
 } from './actions';
 import { localizedCurrencySelector, currencyDisclaimerSelector, paymentSelector } from './selectors';
+import Cookies from 'universal-cookie';
+
+jest.mock('universal-cookie', () => {
+  class MockCookies {
+    static result = {};
+
+    get() {
+      return MockCookies.result;
+    }
+  }
+  return MockCookies;
+});
 
 describe('redux tests', () => {
   let store;
@@ -30,16 +42,12 @@ describe('redux tests', () => {
       });
 
       it('should work for USD', () => {
-        store = createStore(combineReducers({ payment: reducer }), {
-          payment: {
-            currency: {
-              currencyCode: 'USD',
-              conversionRate: 1,
-            },
-          },
-        });
+        Cookies.result = {
+          code: 'USD',
+          rate: 1,
+        };
 
-        const result = localizedCurrencySelector(store.getState());
+        const result = localizedCurrencySelector();
         expect(result).toEqual({
           currencyCode: 'USD',
           conversionRate: 1,
@@ -48,16 +56,12 @@ describe('redux tests', () => {
       });
 
       it('should work for EUR', () => {
-        store = createStore(combineReducers({ payment: reducer }), {
-          payment: {
-            currency: {
-              currencyCode: 'EUR',
-              conversionRate: 1.5,
-            },
-          },
-        });
+        Cookies.result = {
+          code: 'EUR',
+          rate: 1.5,
+        };
 
-        const result = localizedCurrencySelector(store.getState());
+        const result = localizedCurrencySelector();
         expect(result).toEqual({
           currencyCode: 'EUR',
           conversionRate: 1.5,
@@ -192,12 +196,6 @@ describe('redux tests', () => {
         expect(store.getState().payment.basket.loading).toBe(false);
         expect(store.getState().payment.basket.loaded).toBe(true);
       });
-    });
-  });
-
-  describe('currency reducer', () => {
-    it('should return its default state', () => {
-      expect(store.getState().payment.currency).toEqual({});
     });
   });
 });

--- a/src/payment/data/selectors.js
+++ b/src/payment/data/selectors.js
@@ -1,16 +1,26 @@
 import { App } from '@edx/frontend-base';
 import { createSelector } from 'reselect';
 import { localeSelector, getCountryList } from '@edx/frontend-i18n';
+import Cookies from 'universal-cookie';
 
 export const storeName = 'payment';
 
-export const localizedCurrencySelector = (state) => {
-  const { currencyCode, conversionRate } = state[storeName].currency;
+export const localizedCurrencySelector = () => {
+  const cookie = new Cookies().get(App.config.CURRENCY_COOKIE_NAME);
+  let currencyCode;
+  let conversionRate;
+
+  if (cookie && typeof cookie.code === 'string' && typeof cookie.rate === 'number') {
+    currencyCode = cookie.code;
+    conversionRate = cookie.rate;
+  }
+
+  const showAsLocalizedCurrency = typeof currencyCode === 'string' ? currencyCode !== 'USD' : false;
 
   return {
     currencyCode,
     conversionRate,
-    showAsLocalizedCurrency: typeof currencyCode === 'string' ? currencyCode !== 'USD' : false,
+    showAsLocalizedCurrency,
   };
 };
 


### PR DESCRIPTION
We need to wait long enough for the app to know the name of the cookie via CURRENCY_COOKIE_NAME, which is attached to App.config during the startup sequence.  By reading the cookie during a selector instead of at load-time in the reducers file, we sufficiently delay that it picks up the real cookie value.

This means the currency reducer is no longer needed, as the selector reads it from the cookie itself.  That necessitates cleaning up a bunch of reducer/state related setup in our tests.