### PR TITLE
Remove PaymentForm loading performance mark

### DIFF
--- a/src/payment/checkout/payment-form/PaymentForm.jsx
+++ b/src/payment/checkout/payment-form/PaymentForm.jsx
@@ -23,16 +23,6 @@ export class PaymentFormComponent extends React.Component {
     markPerformanceIfAble('Payment Form component rendered');
   }
 
-  componentDidUpdate(prevProps) {
-    if (
-      this.props.loading !== prevProps.loading
-      && !this.props.loading
-    ) {
-      // Send a SpeedCurve event when we stop loading for the first time
-      markPerformanceIfAble('Payment form finished loading');
-    }
-  }
-
   onSubmit = (values) => {
     // istanbul ignore if
     if (this.props.disabled) return;


### PR DESCRIPTION
This has almost exactly the same timing as "Order Summary component
rendered", so let's get rid of this one and instead use "Payment Form
component rendered" to get a sense of when the right side of the page
comes in

In case we decide to close https://github.com/edx/frontend-app-payment/pull/280