### PR TITLE
Update form to be editable on load

### DIFF
--- a/src/payment/__snapshots__/PaymentPage.test.jsx.snap
+++ b/src/payment/__snapshots__/PaymentPage.test.jsx.snap
@@ -8216,7 +8216,7 @@ exports[`<PaymentPage /> Renders correctly in various states should render the b
               className="row form-group justify-content-start align-items-center"
             >
               <div
-                className="col-1 pr-0 pl-2"
+                className="col-0 pr-0 pl-3"
               >
                 <input
                   checked={false}

--- a/src/payment/__snapshots__/PaymentPage.test.jsx.snap
+++ b/src/payment/__snapshots__/PaymentPage.test.jsx.snap
@@ -2506,7 +2506,7 @@ exports[`<PaymentPage /> Renders correctly in various states should render its d
                 <input
                   autoComplete="given-name"
                   className="form-control"
-                  disabled={true}
+                  disabled={false}
                   id="firstName"
                   name="firstName"
                   onBlur={[Function]}
@@ -2532,7 +2532,7 @@ exports[`<PaymentPage /> Renders correctly in various states should render its d
                 <input
                   autoComplete="family-name"
                   className="form-control"
-                  disabled={true}
+                  disabled={false}
                   id="lastName"
                   name="lastName"
                   onBlur={[Function]}
@@ -2562,7 +2562,7 @@ exports[`<PaymentPage /> Renders correctly in various states should render its d
                 <input
                   autoComplete="street-address"
                   className="form-control"
-                  disabled={true}
+                  disabled={false}
                   id="address"
                   maxLength="60"
                   name="address"
@@ -2589,7 +2589,7 @@ exports[`<PaymentPage /> Renders correctly in various states should render its d
                 <input
                   autoComplete="address-line2"
                   className="form-control"
-                  disabled={true}
+                  disabled={false}
                   id="unit"
                   maxLength="29"
                   name="unit"
@@ -2619,7 +2619,7 @@ exports[`<PaymentPage /> Renders correctly in various states should render its d
                 <input
                   autoComplete="address-level2"
                   className="form-control"
-                  disabled={true}
+                  disabled={false}
                   id="city"
                   maxLength="32"
                   name="city"
@@ -2646,7 +2646,7 @@ exports[`<PaymentPage /> Renders correctly in various states should render its d
                 <select
                   autoComplete="country"
                   className="form-control"
-                  disabled={true}
+                  disabled={false}
                   id="country"
                   name="country"
                   onBlur={[Function]}
@@ -3930,7 +3930,7 @@ exports[`<PaymentPage /> Renders correctly in various states should render its d
                 </label>
                 <input
                   className="form-control"
-                  disabled={true}
+                  disabled={false}
                   id="state"
                   name="state"
                   onBlur={[Function]}
@@ -3955,7 +3955,7 @@ exports[`<PaymentPage /> Renders correctly in various states should render its d
                 <input
                   autoComplete="postal-code"
                   className="form-control"
-                  disabled={true}
+                  disabled={false}
                   id="postalCode"
                   maxLength="9"
                   name="postalCode"
@@ -3996,7 +3996,7 @@ exports[`<PaymentPage /> Renders correctly in various states should render its d
                 <input
                   autoComplete="cc-number"
                   className="form-control"
-                  disabled={true}
+                  disabled={false}
                   id="cardNumber"
                   maxLength="20"
                   name="cardNumber"
@@ -4072,7 +4072,7 @@ exports[`<PaymentPage /> Renders correctly in various states should render its d
                 <input
                   autoComplete="cc-csc"
                   className="form-control"
-                  disabled={true}
+                  disabled={false}
                   id="securityCode"
                   maxLength="4"
                   name="securityCode"
@@ -4120,7 +4120,7 @@ exports[`<PaymentPage /> Renders correctly in various states should render its d
                 <select
                   autoComplete="cc-exp-month"
                   className="form-control"
-                  disabled={true}
+                  disabled={false}
                   id="cardExpirationMonth"
                   name="cardExpirationMonth"
                   onBlur={[Function]}
@@ -4211,7 +4211,7 @@ exports[`<PaymentPage /> Renders correctly in various states should render its d
                 <select
                   autoComplete="cc-exp-year"
                   className="form-control"
-                  disabled={true}
+                  disabled={false}
                   id="cardExpirationYear"
                   name="cardExpirationYear"
                   onBlur={[Function]}

--- a/src/payment/checkout/Checkout.jsx
+++ b/src/payment/checkout/Checkout.jsx
@@ -73,8 +73,9 @@ class Checkout extends React.Component {
     const {
       intl,
       isFreeBasket,
-      loading,
       isBasketProcessing,
+      loading,
+      loaded,
       isPaymentVisualExperiment,
       paymentMethod,
       submitting,
@@ -83,6 +84,7 @@ class Checkout extends React.Component {
 
     const submissionDisabled = loading || isBasketProcessing;
     const isBulkOrder = orderType === ORDER_TYPES.BULK_ENROLLMENT;
+    const isQuantityUpdating = isBasketProcessing && loaded;
 
     // istanbul ignore next
     const payPalIsSubmitting = submitting && paymentMethod === 'paypal';
@@ -130,10 +132,11 @@ class Checkout extends React.Component {
         <PaymentForm
           onSubmitPayment={this.handleSubmitCybersource}
           onSubmitButtonClick={this.handleSubmitCybersourceButtonClick}
-          disabled={submissionDisabled}
+          disabled={submitting}
           loading={loading}
           isProcessing={cybersourceIsSubmitting}
           isBulkOrder={isBulkOrder}
+          isQuantityUpdating={isQuantityUpdating}
           isPaymentVisualExperiment={isPaymentVisualExperiment}
         />
       </React.Fragment>
@@ -155,6 +158,7 @@ class Checkout extends React.Component {
 Checkout.propTypes = {
   intl: intlShape.isRequired,
   loading: PropTypes.bool,
+  loaded: PropTypes.bool,
   submitPayment: PropTypes.func.isRequired,
   isFreeBasket: PropTypes.bool,
   submitting: PropTypes.bool,
@@ -166,6 +170,7 @@ Checkout.propTypes = {
 
 Checkout.defaultProps = {
   loading: false,
+  loaded: false,
   submitting: false,
   isBasketProcessing: false,
   isFreeBasket: false,

--- a/src/payment/checkout/payment-form/CardHolderInformation.jsx
+++ b/src/payment/checkout/payment-form/CardHolderInformation.jsx
@@ -154,7 +154,7 @@ export class CardHolderInformationComponent extends React.Component {
 
           {showBulkEnrollmentFields ? (
             <div className="row form-group justify-content-start align-items-center">
-              <div className="col-1 pr-0 pl-2">
+              <div className="col-0 pr-0 pl-3">
                 <Field
                   id="purchasedForOrganization"
                   name="purchasedForOrganization"
@@ -363,7 +363,7 @@ export class CardHolderInformationComponent extends React.Component {
         </div>
         {showBulkEnrollmentFields ? (
           <div className="row form-group justify-content-start align-items-center">
-            <div className="col-1 pr-0 pl-2">
+            <div className="col-0 pr-0 pl-3">
               <Field
                 id="purchasedForOrganization"
                 name="purchasedForOrganization"

--- a/src/payment/checkout/payment-form/PaymentForm.jsx
+++ b/src/payment/checkout/payment-form/PaymentForm.jsx
@@ -198,6 +198,7 @@ export class PaymentFormComponent extends React.Component {
       disabled,
       isProcessing,
       isBulkOrder,
+      isQuantityUpdating,
       isPaymentVisualExperiment,
     } = this.props;
 
@@ -222,7 +223,7 @@ export class PaymentFormComponent extends React.Component {
         <div className="row justify-content-end">
           <div className="col-lg-6 form-group">
             {
-              loading ? (
+              loading || isQuantityUpdating ? (
                 <div className="skeleton btn btn-block btn-lg rounded-pill">&nbsp;</div>
               ) : (
                 <StatefulButton
@@ -262,6 +263,7 @@ PaymentFormComponent.propTypes = {
   disabled: PropTypes.bool,
   isProcessing: PropTypes.bool,
   isBulkOrder: PropTypes.bool,
+  isQuantityUpdating: PropTypes.bool,
   isPaymentVisualExperiment: PropTypes.bool,
   loading: PropTypes.bool,
   onSubmitPayment: PropTypes.func.isRequired,
@@ -272,6 +274,7 @@ PaymentFormComponent.defaultProps = {
   disabled: false,
   loading: true,
   isBulkOrder: false,
+  isQuantityUpdating: false,
   isProcessing: false,
   isPaymentVisualExperiment: false,
 };

--- a/src/payment/index.scss
+++ b/src/payment/index.scss
@@ -124,6 +124,11 @@
     font-size: 1rem;
     display: block;
   }
+
+  #purchasedForOrganization {
+    width: 18px;
+    height: 18px;
+  }
 }
 
 #securityCodeHelp {


### PR DESCRIPTION
[REV-937](https://openedx.atlassian.net/browse/REV-937).
Enable form fields to be editable while basket is loading.
Disable form fields onSubmit of form. 
![Screen Shot 2019-10-29 at 3 41 09 PM](https://user-images.githubusercontent.com/13632680/67802993-8f559380-fa62-11e9-8cb9-0df9cb1efaca.png)
![Screen Shot 2019-10-29 at 3 49 40 PM](https://user-images.githubusercontent.com/13632680/67803587-bfe9fd00-fa63-11e9-8c32-e5e3394531ef.png)

Bulk Purchase - quantity updating disable submit button. 
![Screen Shot 2019-10-31 at 10 34 27 AM](https://user-images.githubusercontent.com/13632680/67956183-0f4a3d80-fbca-11e9-82a5-512f5ea7026f.png)
*Note: updated CSS of checkbox, on zoom in Chrome the size changes to an abnormally large size. 