### PR TITLE
preload optimizely snippet from cloudflare worker

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -15,7 +15,7 @@
     <% }); %>
 
     <% if (htmlWebpackPlugin.options.optimizelyId) { %>
-    <script src="https://cdn.optimizely.com/js/<%= htmlWebpackPlugin.options.optimizelyId %>.js"></script>
+    <script rel="preload" src="/optimizelyjs/<%= htmlWebpackPlugin.options.optimizelyId %>.js"></script>
     <% } %>
   </head>
   <body>


### PR DESCRIPTION
This makes two changes that should improve optimizely performance
1. adds preload tag to the optimizely snippet
2. changes optimizely snippet to load from a cloudflare worker (that should be caching our js at https://payment.edx.org/optimizelyjs/1743970571.js)

Hoping to deploy this and then hopefully see a performance improvement when inspecting optimizely in speedcurve