### PR TITLE
Add card masking to visual experiment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7894,8 +7894,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7916,14 +7915,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7938,20 +7935,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8068,8 +8062,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8081,7 +8074,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8096,7 +8088,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -8104,14 +8095,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -8130,7 +8119,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8211,8 +8199,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8224,7 +8211,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8310,8 +8296,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8347,7 +8332,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8367,7 +8351,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8411,14 +8394,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -9678,6 +9659,11 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
+    },
+    "inputmask": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/inputmask/-/inputmask-4.0.9.tgz",
+      "integrity": "sha512-EodaYhJKncXRBwvCE8YrRmAFmBJ6bWdgX4Qw8QSnK5GBDXE03jgpJhrS+a2N0v2Zsgp+OjKXy7qACktjYD83Uw=="
     },
     "inquirer": {
       "version": "6.5.2",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "babel-polyfill": "6.26.0",
     "classnames": "2.2.6",
     "form-urlencoded": "4.0.0",
+    "inputmask": "4.0.9",
     "lodash.camelcase": "4.3.0",
     "lodash.pick": "4.4.0",
     "lodash.snakecase": "4.1.1",

--- a/src/payment/checkout/payment-form/CardDetails.jsx
+++ b/src/payment/checkout/payment-form/CardDetails.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ReactTooltip from 'react-tooltip';
+import Inputmask from 'inputmask';
 import { Field } from 'redux-form';
 import { faLock, faQuestionCircle } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -20,6 +21,25 @@ export class CardDetailsComponent extends React.Component {
     this.state = {
       cardIcon: null,
     };
+  }
+
+  componentDidMount() {
+    if (this.props.isPaymentVisualExperiment) {
+      // For `inputmask`, 9 allows any number and {n} allows n repeats of the previous symbol
+      const cardFormats = [
+        '4999 9{4} 9{4} 9{4}', // Visa
+        '5999 9{4} 9{4} 9{4}', // Mastercard
+        '6999 9{4} 9{4} 9{4}', // Discover
+        '3999 9{6} 9{5}', // American Express
+      ];
+      const cardNumberMask = new Inputmask({
+        mask: cardFormats,
+        // Makes the mask dynamic so that entering 3 at the beginning will switch to the AMEX format
+        keepStatic: false,
+      });
+      const cardNumberInput = document.getElementById('cardNumber');
+      cardNumberMask.mask(cardNumberInput);
+    }
   }
 
   getNumericOptions(start, end) {


### PR DESCRIPTION
[REV-911](https://openedx.atlassian.net/browse/REV-911)

Supported cards come from: https://support.edx.org/hc/en-us/articles/206502498-How-do-I-pay-
Card formats taken from http://wysiwyg.co.il/Anatomy-of-CreditCard-Number-formats.asp and just searching around

**Visa Format**
![Screenshot_2019-10-31 Payment edX](https://user-images.githubusercontent.com/14864970/67979921-a5df2480-fbf3-11e9-952a-210272dc8ab5.png)

**AMEX Format**:
![Screenshot_2019-10-31 Payment edX(1)](https://user-images.githubusercontent.com/14864970/67979885-9364eb00-fbf3-11e9-89c6-abba8b115a7f.png)


