### PR TITLE
Revert "Revert "preload optimizely snippet from cloudflare worker""

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8831,9 +8831,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.0.tgz",
-      "integrity": "sha512-xkRtOt3/3DzTKMOt3xahj2M/EqNhY988T+imYSlMgs5fVhLN2fmKVVj0LtEGmb+3UUYV5Qmm1052Mm3dIQxOvw==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
+      "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",

--- a/public/index.html
+++ b/public/index.html
@@ -15,7 +15,7 @@
     <% }); %>
 
     <% if (htmlWebpackPlugin.options.optimizelyId) { %>
-    <script src="https://cdn.optimizely.com/js/<%= htmlWebpackPlugin.options.optimizelyId %>.js"></script>
+    <script rel="preload" src="/optimizelyjs/<%= htmlWebpackPlugin.options.optimizelyId %>.js"></script>
     <% } %>
   </head>
   <body>


### PR DESCRIPTION
i have a call with optimizely on thursday to check my implementation of this so i'd like to add it back, at least temporarily
the jump last time this happened that stayed after reverting was weird, so hopefully this also shows whether it causes a jump in visually complete again


(if it does, i think this might be what was happening)
1. https://cdn.optimizely.com/js/1743970571.js gets loaded on login page (which is being excluded from the speedcurve performance with logData 0)
2. that url gets cached and doesn't add a request to webpagetest
3. when i changed the url on frontend-app-payment only, the url could no longer be retrieved from the browser cache