### PR TITLE
Force refresh the jwt cookie before all post requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8831,9 +8831,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
-      "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -6,6 +6,7 @@ import ReactDOM from 'react-dom';
 import { Route, Switch } from 'react-router-dom';
 
 import { sendTrackEvent } from '@edx/frontend-analytics';
+import { logError } from '@edx/frontend-logging';
 import Header, { messages as headerMessages } from '@edx/frontend-component-header';
 import Footer, { messages as footerMessages } from '@edx/frontend-component-footer';
 
@@ -46,7 +47,7 @@ App.subscribe(APP_AUTHENTICATED, () => {
 
   // Temporary fix for ARCH-1304
   // Force refresh the jwt cookie before any post request.
-  // This should be unneeded but some requests are failing
+  // This should be unnecessary but some requests are failing
   // with a JWT expired error on the server. This ensures
   // that the jwt cookie sent to the server for any post request
   // is brand new and therefore less likely to have any timing

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -43,6 +43,25 @@ App.subscribe(APP_ERROR, (error) => {
 
 App.subscribe(APP_AUTHENTICATED, () => {
   App.apiClient.interceptors.response.use(responseInterceptor);
+
+  // Temporary fix for ARCH-1304
+  // Force refresh the jwt cookie before any post request.
+  // This should be unneeded but some requests are failing
+  // with a JWT expired error on the server. This ensures
+  // that the jwt cookie sent to the server for any post request
+  // is brand new and therefore less likely to have any timing
+  // problems.
+  App.apiClient.interceptors.request.use(async (requestConfig) => {
+    if (requestConfig.method === 'post') {
+      try {
+        await fetch(process.env.REFRESH_ACCESS_TOKEN_ENDPOINT, { method: 'POST' });
+      } catch (e) {
+        logError(new Error('There was a failure to force refresh the jwt token. (In temporary fix for ARCH-1304)'));
+      }
+    }
+
+    return requestConfig;
+  });
 });
 
 App.initialize({


### PR DESCRIPTION
Related to ARCH-1304.

Some users payment submissions fail with a jwt expiration error on the server. It's unclear why the this client application doesn't see the jwt as expire too. We will investigate. Temporarily this fix will refresh the jwt cookie before every post request on the page to ensure the jwt cookie is as fresh as it could be. We will see if this eliminates the errors.

Also, this includes upgrades to satisfy npm audit.