### PR TITLE
switch optimizely snippet

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -15,7 +15,7 @@
     <% }); %>
 
     <% if (htmlWebpackPlugin.options.optimizelyId) { %>
-    <script src="https://cdn.optimizely.com/js/<%= htmlWebpackPlugin.options.optimizelyId %>.js"></script>
+    <script src="https://www.edx.org/optimizelyjs/<%= htmlWebpackPlugin.options.optimizelyId %>.js"></script>
     <% } %>
   </head>
   <body>


### PR DESCRIPTION
i've shown that switching the snippet to request from payment.edx.org instead of cdn.optimizely.com set the dns, connect, and ssl portions of the request to 0ms
however, this was not ideal because payment.edx.org will not be in the browser cache and so might actually perform worse on the whole
if using edx.org will create the same benefit for the dns/connect/ssl portions of the request, then this would be the ideal scenario for both when the content is cached and when it is not cached