### PR TITLE
[REV-1074] Copy static checkout pages 

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "axios-mock-adapter": "1.17.0",
     "chance": "1.1.0",
     "clean-webpack-plugin": "3.0.0",
+    "copy-webpack-plugin": "^5.1.1",
     "dotenv-webpack": "1.7.0",
     "enzyme": "3.10.0",
     "enzyme-adapter-react-16": "1.14.0",

--- a/public/REV1074/test.html
+++ b/public/REV1074/test.html
@@ -1,0 +1,1 @@
+<strong>Hello World</strong>

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -3,6 +3,7 @@ const glob = require('glob');
 const PurgecssPlugin = require('purgecss-webpack-plugin');
 const Dotenv = require('dotenv-webpack');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+const CopyPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const NewRelicSourceMapPlugin = require('new-relic-source-map-webpack-plugin');
@@ -29,6 +30,14 @@ config.plugins = [
   new MiniCssExtractPlugin({
     filename: '[name].[chunkhash].css',
   }),
+  // Copies over static html checkout pages to dist folder for the REV-1074 experiment
+  // Stage also uses this config and dev uses this config when running npm run build
+  new CopyPlugin([
+    {
+      from: path.resolve(__dirname, 'public/REV1074'),
+      to: path.resolve(__dirname, 'dist'),
+    },
+  ]),
   // Generates an HTML file in the output directory.
   new HtmlWebpackPlugin({
     inject: false, // Manually inject head and body tags in the template itself.


### PR DESCRIPTION
to the dist folder where they will be accessible through a url

This is necessary because the html for those pages needs to be in the dist folder to be publicly accessible
https://openedx.atlassian.net/browse/REV-1112
@edx/revenue-squad 