### PR TITLE
Added events using the same mechanism as static checkout pages

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -21,7 +21,7 @@ import Header, { messages as headerMessages } from '@edx/frontend-component-head
 import Footer, { messages as footerMessages } from '@edx/frontend-component-footer';
 
 import appMessages from './i18n';
-import { PaymentPage, EcommerceRedirect, responseInterceptor, markPerformanceIfAble, getPerformanceProperties } from './payment';
+import { PaymentPage, EcommerceRedirect, responseInterceptor, markPerformanceIfAble, getPerformanceProperties, sendRev1074Event } from './payment';
 import configureStore from './data/configureStore';
 
 import './index.scss';
@@ -49,6 +49,8 @@ subscribe(APP_READY, () => {
     'edx.bi.ecommerce.payment_mfe.started_painting',
     getPerformanceProperties(),
   );
+  sendRev1074Event('payment_mfe.started_painting', {});
+
   ReactDOM.render(
     <AppProvider store={configureStore()}>
       <Header />

--- a/src/payment/cart/OrderSummary.jsx
+++ b/src/payment/cart/OrderSummary.jsx
@@ -14,7 +14,9 @@ class OrderSummary extends React.Component {
       getPerformanceProperties(),
     );
     let eventData = {};
-    let renderTime = window.performance.getEntriesByName("Order Summary component rendered");
+    let renderTime = window.performance &&
+      window.performance.getEntriesByName &&
+      window.performance.getEntriesByName("Order Summary component rendered");
     if (renderTime) {
       eventData["summaryRenderTiming"] = renderTime[renderTime.length - 1].toJSON();
     }

--- a/src/payment/cart/OrderSummary.jsx
+++ b/src/payment/cart/OrderSummary.jsx
@@ -4,6 +4,7 @@ import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 
 import { markPerformanceIfAble, getPerformanceProperties } from '../performanceEventing';
+import { sendRev1074Event } from '..';
 
 class OrderSummary extends React.Component {
   componentDidMount() {
@@ -12,6 +13,12 @@ class OrderSummary extends React.Component {
       'edx.bi.ecommerce.payment_mfe.order_summary_rendered',
       getPerformanceProperties(),
     );
+    let eventData = {};
+    let renderTime = window.performance.getEntriesByName("Order Summary component rendered");
+    if (renderTime) {
+      eventData["summaryRenderTiming"] = renderTime[renderTime.length - 1].toJSON();
+    }
+    sendRev1074Event('payment_mfe.order_summary_rendered', eventData);
   }
 
   render() {

--- a/src/payment/checkout/Checkout.jsx
+++ b/src/payment/checkout/Checkout.jsx
@@ -10,6 +10,7 @@ import { paymentSelector } from '../data/selectors';
 import { submitPayment } from '../data/actions';
 import AcceptedCardLogos from './assets/accepted-card-logos.png';
 
+import { sendRev1074Event } from '../../payment';
 import PaymentForm from './payment-form/PaymentForm';
 import FreeCheckoutOrderButton from './FreeCheckoutOrderButton';
 import { PayPalButton } from '../payment-methods/paypal';
@@ -24,6 +25,7 @@ class Checkout extends React.Component {
       'edx.bi.ecommerce.basket.payment_selected',
       { type: 'click', category: 'checkout', paymentMethod: 'PayPal' },
     );
+    sendRev1074Event('payment_mfe.payment_selected', { type: 'click', category: 'checkout', paymentMethod: 'PayPal' });
 
     this.props.submitPayment({ method: 'paypal' });
   }
@@ -36,6 +38,7 @@ class Checkout extends React.Component {
       'edx.bi.ecommerce.basket.payment_selected',
       { type: 'click', category: 'checkout', paymentMethod: 'Apple Pay' },
     );
+    sendRev1074Event('payment_mfe.payment_selected', { type: 'click', category: 'checkout', paymentMethod: 'Apple Pay' });
 
     this.props.submitPayment({ method: 'apple-pay' });
   }
@@ -53,6 +56,15 @@ class Checkout extends React.Component {
     // Check for PayPal, ApplePay and Free Basket as well
     sendTrackEvent(
       'edx.bi.ecommerce.basket.payment_selected',
+      {
+        type: 'click',
+        category: 'checkout',
+        paymentMethod: 'Credit Card',
+        checkoutType: 'client_side',
+      },
+    );
+    sendRev1074Event(
+      'payment_mfe.payment_selected',
       {
         type: 'click',
         category: 'checkout',

--- a/src/payment/index.js
+++ b/src/payment/index.js
@@ -2,9 +2,9 @@ import { getConfig } from '@edx/frontend-platform';
 
 
 // HACK: short-lived function to send some testing events; sticking it here since there doesn't
-// seem to be a general 'utils' file
+// seem to be a general 'utils' file.
 // HACK: deliberately not doing this through the regular sendTrackEvent system to more closely
-// match how these will be sent in the static page test
+// match how these will be sent in the static page test.
 /* eslint-disable no-param-reassign */
 /* eslint-disable prefer-template */
 /* eslint-disable dot-notation */

--- a/src/payment/index.js
+++ b/src/payment/index.js
@@ -1,3 +1,33 @@
+import { getConfig } from '@edx/frontend-platform';
+
+
+// HACK: short-lived function to send some testing events; sticking it here since there doesn't
+// seem to be a general 'utils' file
+// HACK: deliberately not doing this through the regular sendTrackEvent system to more closely
+// match how these will be sent in the static page test
+/* eslint-disable no-param-reassign */
+/* eslint-disable prefer-template */
+/* eslint-disable dot-notation */
+export function sendRev1074Event(eventType, eventData) {
+  eventData['_export'] = 'false'; // Don't let these events be exported to partners
+  if (window.performance.timing) {
+    eventData.timing = window.performance.timing.toJSON();
+  }
+  const encodedEvent = [
+    'event_type=edx.experiment.rev1074.' + encodeURIComponent(eventType),
+    'page=' + encodeURIComponent(window.location.href),
+    'event=' + encodeURIComponent(JSON.stringify(eventData)),
+  ].join('&').replace(/%20/g, '+');
+
+  const eventUrl = getConfig().LMS_BASE_URL + '/event';
+  const xhr = new XMLHttpRequest();
+  xhr.open('GET', eventUrl + '?' + encodedEvent);
+  xhr.send();
+}
+/* eslint-enable no-param-reassign */
+/* eslint-enable prefer-template */
+/* eslint-enable dot-notation */
+
 export { default as PaymentPage } from './PaymentPage';
 export { default as reducer } from './data/reducers';
 export { default as saga } from './data/sagas';

--- a/src/payment/index.js
+++ b/src/payment/index.js
@@ -10,7 +10,7 @@ import { getConfig } from '@edx/frontend-platform';
 /* eslint-disable dot-notation */
 export function sendRev1074Event(eventType, eventData) {
   eventData['_export'] = 'false'; // Don't let these events be exported to partners
-  if (window.performance.timing) {
+  if (window.performance && window.performance.timing) {
     eventData.timing = window.performance.timing.toJSON();
   }
   const encodedEvent = [

--- a/src/payment/index.js
+++ b/src/payment/index.js
@@ -14,8 +14,8 @@ export function sendRev1074Event(eventType, eventData) {
     eventData.timing = window.performance.timing.toJSON();
   }
   const encodedEvent = [
-    'event_type=edx.experiment.rev1074.' + encodeURIComponent(eventType),
-    'page=' + encodeURIComponent(window.location.href),
+    'event_type=edx.experiment.rev1074.' + eventType,
+    'page=' + window.location.href,
     'event=' + encodeURIComponent(JSON.stringify(eventData)),
   ].join('&').replace(/%20/g, '+');
 


### PR DESCRIPTION
Added some test events using the same mechanism we intend to use for REV-1074 static checkout pages

Note that I wrote the `sendRev1074Event` with an eye to being able to just drop it into the static pages when we add events there.