### PR TITLE
Update payment declined message.

### DIFF
--- a/src/payment/AlertCodeMessages.jsx
+++ b/src/payment/AlertCodeMessages.jsx
@@ -70,19 +70,8 @@ export const TransactionDeclined = () => (
   <React.Fragment>
     <FormattedMessage
       id="payment.messages.transaction.declined.body"
-      defaultMessage="Please double-check the information you provided and try again. For help, {link}."
-      description="Asks the user to check their information and includes a link to contact support for help."
-      values={{
-        link: (
-          <Hyperlink destination={getConfig().SUPPORT_URL}>
-            <FormattedMessage
-              id="payment.error.fetch.basket.support.fragment"
-              defaultMessage="contact support"
-              description="The support link as in 'please {contact support}'"
-            />
-          </Hyperlink>
-        ),
-      }}
+      defaultMessage="Your payment could not be processed. Please check your payment information or reach out to your bank or financial institution for further assistance."
+      description="Asks the user to check their information or contact their payment provider for help."
     />
   </React.Fragment>
 );

--- a/src/payment/__snapshots__/AlertCodeMessages.test.jsx.snap
+++ b/src/payment/__snapshots__/AlertCodeMessages.test.jsx.snap
@@ -38,16 +38,6 @@ Array [
 
 exports[`TransactionDeclined should render with values 1`] = `
 <span>
-  Please double-check the information you provided and try again. For help, 
-  <a
-    href="http://localhost:18000/support"
-    onClick={[Function]}
-    target="_self"
-  >
-    <span>
-      contact support
-    </span>
-  </a>
-  .
+  Your payment could not be processed. Please check your payment information or reach out to your bank or financial institution for further assistance.
 </span>
 `;


### PR DESCRIPTION
Removed support link from payment declined error message and updated the wording to direct learners to their payment provider or bank.

[PROD-1417](https://openedx.atlassian.net/browse/PROD-1417)

![screencapture-localhost-1998-2020-04-02-18_57_36](https://user-images.githubusercontent.com/2851134/78258371-95213a80-7514-11ea-94b2-0a189644e05c.png)
