### PR TITLE
Remove call to SDN search endpoint and associated tests 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,6 @@ and log in with a staff account. Related endpoints:
   - POST /bff/payment/v0/quantity/
   - POST /bff/payment/v0/vouchers/
   - DELETE /bff/payment/v0/vouchers/{voucherid}
-  - POST /api/v2/sdn/search/
   - POST /payment/cybersource/api-submit/
   - POST /payment/cybersource/apple-pay/authorize/
   - POST /payment/cybersource/apple-pay/start-session/


### PR DESCRIPTION
[REV-1125](https://openedx.atlassian.net/browse/REV-1125). 
- Removing the call to the SDN search endpoint (api/v2/sdn/search/) because we've added the SDN check to the Cybersource api submit (payment/cybersource/api-submit), so this will remove the duplicated SDN check. 
- Removing related tests. 