### PR TITLE
Update edx/frontend-build and dependencies 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
 frontend-app-payment
 ====================
 
-Please tag **@edx/arch-team** on any PRs or issues.  Thanks.
+Please tag **@edx/revenue-squad** on any PRs or issues.  Thanks.
 
 Introduction
 ------------


### PR DESCRIPTION
[REV-1350](https://openedx.atlassian.net/browse/REV-1350). 

The package node-sass was removed recently from frontend-build ([Merged](https://github.com/edx/frontend-build/commit/e26860cb117a9f75ecfee4fce18d1b15a032d296)), updating frontend-build to latest version to reflect this change. 

