### PR TITLE
Only fetch the capture key if the microform is enabled

### DIFF
--- a/src/payment/PaymentPage.jsx
+++ b/src/payment/PaymentPage.jsx
@@ -53,7 +53,9 @@ class PaymentPage extends React.Component {
 
   componentDidMount() {
     this.props.fetchBasket();
-    this.props.fetchCaptureKey();
+    if (this.props.flexMicroformEnabled) {
+      this.props.fetchCaptureKey();
+    }
   }
 
   renderContent() {
@@ -170,6 +172,7 @@ PaymentPage.propTypes = {
   isRedirect: PropTypes.bool,
   fetchBasket: PropTypes.func.isRequired,
   fetchCaptureKey: PropTypes.func.isRequired,
+  flexMicroformEnabled: PropTypes.bool,
   summaryQuantity: PropTypes.number,
   summarySubtotal: PropTypes.number,
 };
@@ -177,6 +180,7 @@ PaymentPage.propTypes = {
 PaymentPage.defaultProps = {
   isEmpty: false,
   isRedirect: false,
+  flexMicroformEnabled: false,
   summaryQuantity: undefined,
   summarySubtotal: undefined,
 };


### PR DESCRIPTION
Fetching the capture key eventually triggers the timer for the messages about completing the purchase before the key has to be refreshed, these messages currently get displayed in the old flow with the non-microform fields.