### PR TITLE
Only start capture key timeout if the microform is enabled

### DIFF
--- a/src/payment/PaymentPage.jsx
+++ b/src/payment/PaymentPage.jsx
@@ -53,9 +53,7 @@ class PaymentPage extends React.Component {
 
   componentDidMount() {
     this.props.fetchBasket();
-    if (this.props.flexMicroformEnabled) {
-      this.props.fetchCaptureKey();
-    }
+    this.props.fetchCaptureKey();
   }
 
   renderContent() {
@@ -172,7 +170,6 @@ PaymentPage.propTypes = {
   isRedirect: PropTypes.bool,
   fetchBasket: PropTypes.func.isRequired,
   fetchCaptureKey: PropTypes.func.isRequired,
-  flexMicroformEnabled: PropTypes.bool,
   summaryQuantity: PropTypes.number,
   summarySubtotal: PropTypes.number,
 };
@@ -180,7 +177,6 @@ PaymentPage.propTypes = {
 PaymentPage.defaultProps = {
   isEmpty: false,
   isRedirect: false,
-  flexMicroformEnabled: false,
   summaryQuantity: undefined,
   summarySubtotal: undefined,
 };

--- a/src/payment/data/sagas.js
+++ b/src/payment/data/sagas.js
@@ -154,7 +154,9 @@ export function* handleFetchCaptureKey() {
     yield put(microformStatus(STATUS_LOADING)); // we are refreshing the capture key
     const result = yield call(PaymentApiService.getCaptureKey);
     yield put(captureKeyDataReceived(result)); // update redux store with capture key data
-    yield put(captureKeyStartTimeout());
+    if (isWaffleFlagEnabled('payment.cybersource.flex_microform_enabled', false)) {
+      yield put(captureKeyStartTimeout()); // only start the timer if we're using the capture key
+    }
   } catch (error) {
     yield call(handleErrors, error, true);
   } finally {


### PR DESCRIPTION
Only fetching the capture key if the microform is enabled sometimes failed to do the fetch; moving the check to only affect the timeout and messages.