### PR TITLE
Validate the card type and show the appropriate error

### DIFF
--- a/src/payment/checkout/payment-form/flex-microform/CreditCardNumberField.jsx
+++ b/src/payment/checkout/payment-form/flex-microform/CreditCardNumberField.jsx
@@ -17,11 +17,12 @@ class CreditCardNumberField extends React.Component {
   }
 
   onNumberChange = (data) => {
+    window.microform.fields.number.valid = data.valid;
     let cardIcon = null;
     if (data.card && data.card.length > 0) {
       const { cybsCardType } = data.card[0];
-      cardIcon = getCardIconForType(cybsCardType);
       window.microform.fields.number.cybsCardType = cybsCardType;
+      cardIcon = getCardIconForType(cybsCardType);
     }
     this.setState({ cardIcon });
   };

--- a/src/payment/checkout/payment-form/flex-microform/CreditCardNumberField.jsx
+++ b/src/payment/checkout/payment-form/flex-microform/CreditCardNumberField.jsx
@@ -19,7 +19,9 @@ class CreditCardNumberField extends React.Component {
   onNumberChange = (data) => {
     let cardIcon = null;
     if (data.card && data.card.length > 0) {
-      cardIcon = getCardIconForType(data.card[0].cybsCardType);
+      const { cybsCardType } = data.card[0];
+      cardIcon = getCardIconForType(cybsCardType);
+      window.microform.fields.number.cybsCardType = cybsCardType;
     }
     this.setState({ cardIcon });
   };


### PR DESCRIPTION
Validate the card type and show the appropriate error; still using the old list of card types

Creating a new list of card types for this validation to use with the full compliment Cybersource will process for us will be done separately as part of cleanup, if we choose to do that.
