### PR TITLE
REV-1592 Enable Diners Club and JCB card types

### DIFF
--- a/src/payment/checkout/payment-form/PaymentForm.old.test.jsx
+++ b/src/payment/checkout/payment-form/PaymentForm.old.test.jsx
@@ -220,7 +220,7 @@ describe('<PaymentForm />', () => {
         ['', '', '', '', {}],
         ['', '', `${currentMonth - 1}`, `${currentYear}`, { cardExpirationMonth: 'payment.form.errors.card.expired' }],
         ['41111', '', '', '', { cardNumber: 'payment.form.errors.invalid.card.number' }],
-        ['30569309025904', '', '', '', { cardNumber: 'payment.form.errors.unsupported.card' }],
+        ['6062828888666688', '', '', '', { cardNumber: 'payment.form.errors.unsupported.card' }],
         ['4111-1111-1111-1111', '12345', '', '', { securityCode: 'payment.form.errors.invalid.security.code' }],
       ];
 

--- a/src/payment/checkout/payment-form/utils/credit-card.js
+++ b/src/payment/checkout/payment-form/utils/credit-card.js
@@ -1,6 +1,8 @@
 import {
   faCcAmex,
+  faCcDinersClub,
   faCcDiscover,
+  faCcJcb,
   faCcMastercard,
   faCcVisa,
 } from '@fortawesome/free-brands-svg-icons';
@@ -9,14 +11,18 @@ const CardValidator = require('../../card-validator');
 
 export const CARD_TYPES = {
   'american-express': '003',
+  'diners-club': '005',
   discover: '004',
+  jcb: '007',
   mastercard: '002',
   visa: '001',
 };
 
 export const CARD_ICONS = {
   '003': faCcAmex,
+  '005': faCcDinersClub,
   '004': faCcDiscover,
+  '007': faCcJcb,
   '002': faCcMastercard,
   '001': faCcVisa,
 };

--- a/src/payment/checkout/payment-form/utils/credit-card.test.js
+++ b/src/payment/checkout/payment-form/utils/credit-card.test.js
@@ -5,7 +5,7 @@ import { getCardIcon, getCardTypeId } from './credit-card';
 describe('credit-card', () => {
   describe('getCardIcon', () => {
     it('should return null for unsupported card types', () => {
-      const cardIcon = getCardIcon('36');
+      const cardIcon = getCardIcon('606282');
       expect(cardIcon).toBeNull();
     });
 
@@ -21,7 +21,7 @@ describe('credit-card', () => {
 
   describe('getCardTypeId', () => {
     it('should return null for unsupported card types', () => {
-      const cardIcon = getCardTypeId('36');
+      const cardIcon = getCardTypeId('606282');
       expect(cardIcon).toBeNull();
     });
 


### PR DESCRIPTION
Note: a local test with the Diners test card did not work, I've reached out to ask if it is expected to work in the test environment
UPDATE: apparently those card types are not enabled in our testing profile, looking into updating our profiles now
UPDATE 2: I did not see how to update our test profile, but a test with the REST API succeeded without changing anything; since we are moving off SOP hopefully it will work in prod, but I updated our production SOP profile just in case.