### PR TITLE
Update rebranding styles, retheme with @edx/brand

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1320,6 +1320,11 @@
       "resolved": "https://registry.npmjs.org/@cospired/i18n-iso-languages/-/i18n-iso-languages-2.1.0.tgz",
       "integrity": "sha512-r+bqdtVTkO8R07JiBxEc7ckbkXgeIP/X51MxqxODv9gZovc/MBDS6uJVCHg+mtJuldwvSD6L0XF5RzH6qyAacQ=="
     },
+    "@edx/brand": {
+      "version": "npm:@edx/brand-openedx@1.1.0",
+      "resolved": "https://registry.npmjs.org/@edx/brand-openedx/-/brand-openedx-1.1.0.tgz",
+      "integrity": "sha512-ne2ZKF1r0akkt0rEzCAQAk4cTDTI2GiWCpc+T7ldQpw9X57OnUB16dKsFNe40C9uEjL5h3Ps/ZsFM5dm4cIkEQ=="
+    },
     "@edx/eslint-config": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@edx/eslint-config/-/eslint-config-1.1.5.tgz",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "url": "https://github.com/edx/frontend-app-payment/issues"
   },
   "dependencies": {
+    "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
     "@edx/frontend-component-footer": "10.0.3",
     "@edx/frontend-component-header": "2.0.3",
     "@edx/frontend-platform": "1.1.9",

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,4 +1,7 @@
-@import '~@edx/paragon/scss/edx/theme.scss';
+@import "@edx/brand/paragon/fonts.scss";
+@import "@edx/brand/paragon/variables.scss";
+@import "@edx/paragon/scss/core/core.scss";
+@import "@edx/brand/paragon/overrides.scss";
 
 @import './payment/index.scss';
 

--- a/src/payment/__snapshots__/PaymentPage.test.jsx.snap
+++ b/src/payment/__snapshots__/PaymentPage.test.jsx.snap
@@ -628,6 +628,11 @@ exports[`<PaymentPage /> Renders correctly in various states should render all c
                     onDrop={[Function]}
                     onFocus={[Function]}
                     required={true}
+                    style={
+                      Object {
+                        "MozAppearance": "none",
+                      }
+                    }
                     value=""
                   >
                     <option
@@ -2080,7 +2085,7 @@ exports[`<PaymentPage /> Renders correctly in various states should render all c
               className="col-lg-6 form-group"
             >
               <div
-                className="skeleton btn btn-block btn-lg rounded-pill"
+                className="skeleton btn btn-block btn-lg"
               >
                  
               </div>
@@ -2443,6 +2448,11 @@ exports[`<PaymentPage /> Renders correctly in various states should render its d
                     onDrop={[Function]}
                     onFocus={[Function]}
                     required={true}
+                    style={
+                      Object {
+                        "MozAppearance": "none",
+                      }
+                    }
                     value=""
                   >
                     <option
@@ -3895,7 +3905,7 @@ exports[`<PaymentPage /> Renders correctly in various states should render its d
               className="col-lg-6 form-group"
             >
               <div
-                className="skeleton btn btn-block btn-lg rounded-pill"
+                className="skeleton btn btn-block btn-lg"
               >
                  
               </div>
@@ -4276,6 +4286,11 @@ exports[`<PaymentPage /> Renders correctly in various states should render the b
                     onDrop={[Function]}
                     onFocus={[Function]}
                     required={true}
+                    style={
+                      Object {
+                        "MozAppearance": "none",
+                      }
+                    }
                     value=""
                   >
                     <option
@@ -5728,7 +5743,7 @@ exports[`<PaymentPage /> Renders correctly in various states should render the b
               className="col-lg-6 form-group"
             >
               <div
-                className="skeleton btn btn-block btn-lg rounded-pill"
+                className="skeleton btn btn-block btn-lg"
               >
                  
               </div>
@@ -6262,6 +6277,11 @@ exports[`<PaymentPage /> Renders correctly in various states should render the b
                     onDrop={[Function]}
                     onFocus={[Function]}
                     required={true}
+                    style={
+                      Object {
+                        "MozAppearance": "none",
+                      }
+                    }
                     value=""
                   >
                     <option
@@ -7748,7 +7768,7 @@ exports[`<PaymentPage /> Renders correctly in various states should render the b
               className="col-lg-6 form-group"
             >
               <div
-                className="skeleton btn btn-block btn-lg rounded-pill"
+                className="skeleton btn btn-block btn-lg"
               >
                  
               </div>
@@ -8146,6 +8166,11 @@ exports[`<PaymentPage /> Renders correctly in various states should render the b
                     onDrop={[Function]}
                     onFocus={[Function]}
                     required={true}
+                    style={
+                      Object {
+                        "MozAppearance": "none",
+                      }
+                    }
                     value=""
                   >
                     <option
@@ -9598,7 +9623,7 @@ exports[`<PaymentPage /> Renders correctly in various states should render the b
               className="col-lg-6 form-group"
             >
               <div
-                className="skeleton btn btn-block btn-lg rounded-pill"
+                className="skeleton btn btn-block btn-lg"
               >
                  
               </div>
@@ -10009,6 +10034,11 @@ exports[`<PaymentPage /> Renders correctly in various states should render the b
                     onDrop={[Function]}
                     onFocus={[Function]}
                     required={true}
+                    style={
+                      Object {
+                        "MozAppearance": "none",
+                      }
+                    }
                     value=""
                   >
                     <option
@@ -11461,7 +11491,7 @@ exports[`<PaymentPage /> Renders correctly in various states should render the b
               className="col-lg-6 form-group"
             >
               <div
-                className="skeleton btn btn-block btn-lg rounded-pill"
+                className="skeleton btn btn-block btn-lg"
               >
                  
               </div>

--- a/src/payment/cart/CouponForm.jsx
+++ b/src/payment/cart/CouponForm.jsx
@@ -56,7 +56,7 @@ class CouponForm extends Component {
         </ValidationFormGroup>
         <Button
           disabled={isBasketProcessing}
-          variant="primary"
+          variant="outline-primary"
           type="submit"
           onClick={this.handleSubmitButtonClick}
         >

--- a/src/payment/cart/__snapshots__/Cart.test.jsx.snap
+++ b/src/payment/cart/__snapshots__/Cart.test.jsx.snap
@@ -250,7 +250,7 @@ exports[`<Cart /> renders a basic, one product cart with coupon form 1`] = `
           />
         </div>
         <button
-          className="btn btn-primary"
+          className="btn btn-outline-primary"
           disabled={false}
           onClick={[Function]}
           type="submit"

--- a/src/payment/cart/__snapshots__/CouponForm.test.jsx.snap
+++ b/src/payment/cart/__snapshots__/CouponForm.test.jsx.snap
@@ -48,7 +48,7 @@ exports[`CouponForm should render a form when there is no coupon 1`] = `
     />
   </div>
   <button
-    className="btn btn-primary"
+    className="btn btn-outline-primary"
     disabled={false}
     onClick={[Function]}
     type="submit"

--- a/src/payment/checkout/payment-form/CardHolderInformation.jsx
+++ b/src/payment/checkout/payment-form/CardHolderInformation.jsx
@@ -190,6 +190,7 @@ export class CardHolderInformationComponent extends React.Component {
                 onChange={this.handleSelectCountry}
                 disabled={disabled}
                 autoComplete="country"
+                style={{ MozAppearance: 'none' }}
               />
             </div>
           </div>

--- a/src/payment/checkout/payment-form/PaymentForm.jsx
+++ b/src/payment/checkout/payment-form/PaymentForm.jsx
@@ -203,7 +203,7 @@ export class PaymentFormComponent extends React.Component {
             <div className="col-lg-6 form-group">
               {
                 loading || isQuantityUpdating || !window.microform ? (
-                  <div className="skeleton btn btn-block btn-lg rounded-pill">&nbsp;</div>
+                  <div className="skeleton btn btn-block btn-lg">&nbsp;</div>
                 ) : (
                   <StatefulButton
                     type="submit"

--- a/src/payment/checkout/payment-form/StateProvinceFormInput.jsx
+++ b/src/payment/checkout/payment-form/StateProvinceFormInput.jsx
@@ -40,6 +40,7 @@ class StateProvinceFormInput extends React.Component {
             options={options}
             required
             disabled={disabled}
+            style={{ MozAppearance: 'none' }}
           />
         </>
       );

--- a/src/payment/index.scss
+++ b/src/payment/index.scss
@@ -112,7 +112,6 @@
   }
   .skeleton {
     background-color: rgba(0,0,0, .1);
-    border-radius: $border-radius;
     animation: skeleton-pulse 2s infinite both;
   }
 

--- a/src/payment/index.scss
+++ b/src/payment/index.scss
@@ -129,6 +129,10 @@
     height: 18px;
   }
 
+  #couponField {
+    width: 11rem;
+  }
+
   .num-enrolled {
     display: inline-block;
     background-color: #d8edf8;


### PR DESCRIPTION
[REV-1604](https://openedx.atlassian.net/browse/REV-1604). 
Retheme using @edx/brand.

Pls note: in order to see this branch locally, you need to run `npm install --save @edx/brand@npm:@edx/brand-edx.org` 

More details on UX's feedback on the ticket, screenshots have been approved with the below changes:
1) Loading state skeleton updated to reflect no rounded borders for both form items and submit button. 
<img width="851" alt="Screen Shot 2020-12-06 at 11 29 02 PM" src="https://user-images.githubusercontent.com/13632680/101364739-e4bcc080-3870-11eb-977e-e30599afaf15.png">
<img width="867" alt="Screen Shot 2020-12-06 at 11 31 17 PM" src="https://user-images.githubusercontent.com/13632680/101364743-e5eded80-3870-11eb-9c62-a52e0c9f5df8.png">

2) Coupon button changed to `outline-primary` and field width changed to align with the course title. 
<img width="885" alt="Screen Shot 2020-12-07 at 9 48 14 AM" src="https://user-images.githubusercontent.com/13632680/101365127-66145300-3871-11eb-81f0-a320ff059586.png">
<img width="836" alt="Screen Shot 2020-12-07 at 9 47 35 AM" src="https://user-images.githubusercontent.com/13632680/101365134-67de1680-3871-11eb-9f94-869034671359.png">
<img width="347" alt="Screen Shot 2020-12-07 at 9 49 16 AM" src="https://user-images.githubusercontent.com/13632680/101365240-8c39f300-3871-11eb-87c8-05c79f3ff63b.png">
Mobile:
<img width="460" alt="Screen Shot 2020-12-06 at 10 35 08 PM" src="https://user-images.githubusercontent.com/13632680/101365342-ac69b200-3871-11eb-801a-58331ebc10a8.png">

3) Firefox displayed an issue with a double dropdown in the selector field for country and state. 
![image-20201204-195329](https://user-images.githubusercontent.com/13632680/101365469-d7540600-3871-11eb-9df9-de8306b60409.png)
Fixed: 
<img width="624" alt="Screen Shot 2020-12-07 at 9 00 56 AM" src="https://user-images.githubusercontent.com/13632680/101365492-e2a73180-3871-11eb-90d4-3dc74199e3c9.png">



