### PR TITLE
Revert "Update rebranding styles, retheme with @edx/brand"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1320,11 +1320,6 @@
       "resolved": "https://registry.npmjs.org/@cospired/i18n-iso-languages/-/i18n-iso-languages-2.1.0.tgz",
       "integrity": "sha512-r+bqdtVTkO8R07JiBxEc7ckbkXgeIP/X51MxqxODv9gZovc/MBDS6uJVCHg+mtJuldwvSD6L0XF5RzH6qyAacQ=="
     },
-    "@edx/brand": {
-      "version": "npm:@edx/brand-openedx@1.1.0",
-      "resolved": "https://registry.npmjs.org/@edx/brand-openedx/-/brand-openedx-1.1.0.tgz",
-      "integrity": "sha512-ne2ZKF1r0akkt0rEzCAQAk4cTDTI2GiWCpc+T7ldQpw9X57OnUB16dKsFNe40C9uEjL5h3Ps/ZsFM5dm4cIkEQ=="
-    },
     "@edx/eslint-config": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@edx/eslint-config/-/eslint-config-1.1.5.tgz",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "url": "https://github.com/edx/frontend-app-payment/issues"
   },
   "dependencies": {
-    "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
     "@edx/frontend-component-footer": "10.0.3",
     "@edx/frontend-component-header": "2.0.3",
     "@edx/frontend-platform": "1.1.9",

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,7 +1,4 @@
-@import "@edx/brand/paragon/fonts.scss";
-@import "@edx/brand/paragon/variables.scss";
-@import "@edx/paragon/scss/core/core.scss";
-@import "@edx/brand/paragon/overrides.scss";
+@import '~@edx/paragon/scss/edx/theme.scss';
 
 @import './payment/index.scss';
 

--- a/src/payment/__snapshots__/PaymentPage.test.jsx.snap
+++ b/src/payment/__snapshots__/PaymentPage.test.jsx.snap
@@ -628,11 +628,6 @@ exports[`<PaymentPage /> Renders correctly in various states should render all c
                     onDrop={[Function]}
                     onFocus={[Function]}
                     required={true}
-                    style={
-                      Object {
-                        "MozAppearance": "none",
-                      }
-                    }
                     value=""
                   >
                     <option
@@ -2085,7 +2080,7 @@ exports[`<PaymentPage /> Renders correctly in various states should render all c
               className="col-lg-6 form-group"
             >
               <div
-                className="skeleton btn btn-block btn-lg"
+                className="skeleton btn btn-block btn-lg rounded-pill"
               >
                  
               </div>
@@ -2448,11 +2443,6 @@ exports[`<PaymentPage /> Renders correctly in various states should render its d
                     onDrop={[Function]}
                     onFocus={[Function]}
                     required={true}
-                    style={
-                      Object {
-                        "MozAppearance": "none",
-                      }
-                    }
                     value=""
                   >
                     <option
@@ -3905,7 +3895,7 @@ exports[`<PaymentPage /> Renders correctly in various states should render its d
               className="col-lg-6 form-group"
             >
               <div
-                className="skeleton btn btn-block btn-lg"
+                className="skeleton btn btn-block btn-lg rounded-pill"
               >
                  
               </div>
@@ -4286,11 +4276,6 @@ exports[`<PaymentPage /> Renders correctly in various states should render the b
                     onDrop={[Function]}
                     onFocus={[Function]}
                     required={true}
-                    style={
-                      Object {
-                        "MozAppearance": "none",
-                      }
-                    }
                     value=""
                   >
                     <option
@@ -5743,7 +5728,7 @@ exports[`<PaymentPage /> Renders correctly in various states should render the b
               className="col-lg-6 form-group"
             >
               <div
-                className="skeleton btn btn-block btn-lg"
+                className="skeleton btn btn-block btn-lg rounded-pill"
               >
                  
               </div>
@@ -6277,11 +6262,6 @@ exports[`<PaymentPage /> Renders correctly in various states should render the b
                     onDrop={[Function]}
                     onFocus={[Function]}
                     required={true}
-                    style={
-                      Object {
-                        "MozAppearance": "none",
-                      }
-                    }
                     value=""
                   >
                     <option
@@ -7768,7 +7748,7 @@ exports[`<PaymentPage /> Renders correctly in various states should render the b
               className="col-lg-6 form-group"
             >
               <div
-                className="skeleton btn btn-block btn-lg"
+                className="skeleton btn btn-block btn-lg rounded-pill"
               >
                  
               </div>
@@ -8166,11 +8146,6 @@ exports[`<PaymentPage /> Renders correctly in various states should render the b
                     onDrop={[Function]}
                     onFocus={[Function]}
                     required={true}
-                    style={
-                      Object {
-                        "MozAppearance": "none",
-                      }
-                    }
                     value=""
                   >
                     <option
@@ -9623,7 +9598,7 @@ exports[`<PaymentPage /> Renders correctly in various states should render the b
               className="col-lg-6 form-group"
             >
               <div
-                className="skeleton btn btn-block btn-lg"
+                className="skeleton btn btn-block btn-lg rounded-pill"
               >
                  
               </div>
@@ -10034,11 +10009,6 @@ exports[`<PaymentPage /> Renders correctly in various states should render the b
                     onDrop={[Function]}
                     onFocus={[Function]}
                     required={true}
-                    style={
-                      Object {
-                        "MozAppearance": "none",
-                      }
-                    }
                     value=""
                   >
                     <option
@@ -11491,7 +11461,7 @@ exports[`<PaymentPage /> Renders correctly in various states should render the b
               className="col-lg-6 form-group"
             >
               <div
-                className="skeleton btn btn-block btn-lg"
+                className="skeleton btn btn-block btn-lg rounded-pill"
               >
                  
               </div>

--- a/src/payment/cart/CouponForm.jsx
+++ b/src/payment/cart/CouponForm.jsx
@@ -56,7 +56,7 @@ class CouponForm extends Component {
         </ValidationFormGroup>
         <Button
           disabled={isBasketProcessing}
-          variant="outline-primary"
+          variant="primary"
           type="submit"
           onClick={this.handleSubmitButtonClick}
         >

--- a/src/payment/cart/__snapshots__/Cart.test.jsx.snap
+++ b/src/payment/cart/__snapshots__/Cart.test.jsx.snap
@@ -250,7 +250,7 @@ exports[`<Cart /> renders a basic, one product cart with coupon form 1`] = `
           />
         </div>
         <button
-          className="btn btn-outline-primary"
+          className="btn btn-primary"
           disabled={false}
           onClick={[Function]}
           type="submit"

--- a/src/payment/cart/__snapshots__/CouponForm.test.jsx.snap
+++ b/src/payment/cart/__snapshots__/CouponForm.test.jsx.snap
@@ -48,7 +48,7 @@ exports[`CouponForm should render a form when there is no coupon 1`] = `
     />
   </div>
   <button
-    className="btn btn-outline-primary"
+    className="btn btn-primary"
     disabled={false}
     onClick={[Function]}
     type="submit"

--- a/src/payment/checkout/payment-form/CardHolderInformation.jsx
+++ b/src/payment/checkout/payment-form/CardHolderInformation.jsx
@@ -190,7 +190,6 @@ export class CardHolderInformationComponent extends React.Component {
                 onChange={this.handleSelectCountry}
                 disabled={disabled}
                 autoComplete="country"
-                style={{ MozAppearance: 'none' }}
               />
             </div>
           </div>

--- a/src/payment/checkout/payment-form/PaymentForm.jsx
+++ b/src/payment/checkout/payment-form/PaymentForm.jsx
@@ -203,7 +203,7 @@ export class PaymentFormComponent extends React.Component {
             <div className="col-lg-6 form-group">
               {
                 loading || isQuantityUpdating || !window.microform ? (
-                  <div className="skeleton btn btn-block btn-lg">&nbsp;</div>
+                  <div className="skeleton btn btn-block btn-lg rounded-pill">&nbsp;</div>
                 ) : (
                   <StatefulButton
                     type="submit"

--- a/src/payment/checkout/payment-form/StateProvinceFormInput.jsx
+++ b/src/payment/checkout/payment-form/StateProvinceFormInput.jsx
@@ -40,7 +40,6 @@ class StateProvinceFormInput extends React.Component {
             options={options}
             required
             disabled={disabled}
-            style={{ MozAppearance: 'none' }}
           />
         </>
       );

--- a/src/payment/index.scss
+++ b/src/payment/index.scss
@@ -112,6 +112,7 @@
   }
   .skeleton {
     background-color: rgba(0,0,0, .1);
+    border-radius: $border-radius;
     animation: skeleton-pulse 2s infinite both;
   }
 
@@ -127,10 +128,6 @@
   #purchasedForOrganization {
     width: 18px;
     height: 18px;
-  }
-
-  #couponField {
-    width: 11rem;
   }
 
   .num-enrolled {


### PR DESCRIPTION
Reverts edx/frontend-app-payment#457
edx/brand is not pointing to @edx/brand-edx.org, so it's showing default Bootstrap look instead in https://payment.stage.edx.org/
This merged PR in edx-internal https://github.com/edx/edx-internal/pull/3857 fixes that, but it might have an issue with the order in which they are merged. 