### PR TITLE
Update README to recommend `npm ci`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Getting Started
 
   ``cd frontend-app-payment && npm ci``
 
-  Note: ``npm ci`` is recommended over ``npm install`` to match the way CI and production builds work and avoid unintentional changes to `package_lock.json` when doing other work.
+  Note: ``npm ci`` is recommended over ``npm install`` to match the way CI and production builds work and avoid unintentional changes to ``package_lock.json`` when doing other work.
 
 3. Start the dev server:
 

--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,8 @@ Getting Started
 
   ``cd frontend-app-payment && npm ci``
 
+  Note: ``npm ci`` is recommended over ``npm install`` to match the way CI and production builds work and avoid unintentional changes to `package_lock.json` when doing other work.
+
 3. Start the dev server:
 
   ``npm start``

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Getting Started
 
 2. Install npm dependencies:
 
-  ``cd frontend-app-payment && npm install``
+  ``cd frontend-app-payment && npm ci``
 
 3. Start the dev server:
 
@@ -212,7 +212,7 @@ described below:
   ``127.0.0.1 local.stage.edx.org``.
 
 - Log into stage: `https://courses.stage.edx.org/login <https://courses.stage.edx.org/login>`_.
-- Run `npm install` in this project directory
+- Run `npm ci` in this project directory
 - Start the frontend's dev server in staging mode:
 
   ``npm run start:stage``


### PR DESCRIPTION
Recommend `npm ci` over `npm install` to minimize package_lock changes and match CI and prod builds