### PR TITLE
Clean up audit-ci.json

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -1,6 +1,6 @@
 {
     "allowlist": [
-        "object-path"
+        565, 1675, 1676, 1677, 1693, 1745, 1747
     ],
     "moderate": true
 }


### PR DESCRIPTION
Our pre-commit hook had been failing because of our previous settings in audit-ci.json: 
- object-path was there (which we don't depend on anymore)
- other vulnerabilities: 565, 1675, 1676, 1677, 1693, 1745, 1747 (which we can add directly)

I've updated audit-ci.json accordingly, and now the pre-commit hook no longer fails, and the build checks no longer fail 

Ben has checked these vulnerabilities, and the one that's a prod dependency is sanitize-html <2.3.1 (id 1676), which is used by Paragon- ticket filed to address this here: 
https://openedx.atlassian.net/browse/REV-2249