### PR TITLE
fix: add missing space in state display name

### DIFF
--- a/src/payment/checkout/payment-form/utils/countryStatesMap.js
+++ b/src/payment/checkout/payment-form/utils/countryStatesMap.js
@@ -42,7 +42,7 @@ const COUNTRY_STATES_MAP = {
     TR: 'Tripura',
     UP: 'Uttar Pradesh',
     UT: 'Uttarakhand',
-    WB: 'WestBengal',
+    WB: 'West Bengal',
   },
   US: {
     AL: 'Alabama',


### PR DESCRIPTION
In [REV-2217](https://openedx.atlassian.net/browse/REV-2217) added a state drop-down menu for India. I just noticed a missing space in West Bengal- fixing it in this PR