### PR TITLE
temp!: temporarily required ascii characters in name fields

### DIFF
--- a/src/payment/checkout/payment-form/PaymentForm.jsx
+++ b/src/payment/checkout/payment-form/PaymentForm.jsx
@@ -57,6 +57,10 @@ export class PaymentFormComponent extends React.Component {
 
     const errors = {
       ...this.validateRequiredFields(requiredFields),
+      ...this.validateAsciiNames(
+        firstName,
+        lastName,
+      ),
       ...this.validateCardDetails(
         cardExpirationMonth,
         cardExpirationYear,
@@ -132,6 +136,20 @@ export class PaymentFormComponent extends React.Component {
       && parseInt(cardExpirationYear, 10) === currentYear
     ) {
       errors.cardExpirationMonth = 'payment.form.errors.card.expired';
+    }
+
+    return errors;
+  }
+
+  validateAsciiNames(firstName, lastName) {
+    const errors = {};
+
+    if (
+      firstName
+      && lastName
+      && !/[A-Za-z]/.test(firstName + lastName)
+    ) {
+      errors.firstName = 'payment.form.errors.ascii.name';
     }
 
     return errors;

--- a/src/payment/checkout/payment-form/PaymentForm.messages.jsx
+++ b/src/payment/checkout/payment-form/PaymentForm.messages.jsx
@@ -26,6 +26,11 @@ const messages = defineMessages({
     defaultMessage: 'This field is required',
     description: 'The form field feedback text for missing required field error.',
   },
+  'payment.form.errors.ascii.name': {
+    id: 'payment.form.errors.ascii.name',
+    defaultMessage: 'We apologize for the inconvenience but for the time being we require ASCII characters in the name field. We are working on addressing this and appreciate your patience.',
+    description: 'The form field feedback text for name format issue.',
+  },
 });
 
 export default messages;


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Description
There is an issue with the SDN fallback check that is locking accounts if the name contains no ascii characters.

Added a form validation check that the name fields contain ascii letters as a short-term mitigation for [[REV-2491] Explosion in SDN hits for users with Chinese character names - JIRA](https://openedx.atlassian.net/browse/REV-2491)

It is OK for this to be a client-side check; if anyone circumvents it, they just get their account locked by the bug.

## Testing instructions
This can be tested by attempting to purchase a course and using only non-ascii letters in the name fields, for example `中国人`, adding any ascii letters will allow the fields to validate.

## Checklist
- [x] Consider PCI compliance impact and whether this PR changes how credit card information is handled.
- [x] Intend to [release and monitor](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories) this PR promptly after merge.
