### PR TITLE
feat: Remove Canada from allowed country in DPM BNPL form validation

### DIFF
--- a/src/payment/checkout/payment-form/utils/form-validators.js
+++ b/src/payment/checkout/payment-form/utils/form-validators.js
@@ -106,7 +106,7 @@ export function validateCountryPaymentMethodCompatibility(
   // For Klarna, there is validation on the Stripe API level,
   // which is handled with error code 'dynamic-payment-methods-country-not-compatible'
   if (isDynamicPaymentMethodsEnabled && stripeSelectedPaymentMethod === 'affirm') {
-    const countryListCompatibleAffirm = ['CA', 'US'];
+    const countryListCompatibleAffirm = ['US']; // leaving this is as list in case in the future we have Canada business compatibility
     if (!countryListCompatibleAffirm.includes(selectedCountry)) {
       errors.country = 'payment.form.errors.dynamic_payment_methods_not_compatible.country';
     }


### PR DESCRIPTION
As per our business case, Canada is not supported for BNPL Affirm. Removing it from the allowed countries on our billing address form validation, since for Affirm it only errors at the Affirm payment environment, which would mean an extra step  to display an error for the learner.