### PR TITLE
SONIC-696: Disable Wallets via code in the Legacy Payment Flow

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -3,7 +3,10 @@
         "GHSA-wf5p-g6vw-rhxx",
         "GHSA-rv95-896h-c2vc",
         "GHSA-grv7-fg5c-xmjg",
-        "GHSA-3h5v-q93c-6h6q"
+        "GHSA-3h5v-q93c-6h6q",
+        "GHSA-vc8w-jr9v-vj7f",
+        "GHSA-952p-6rrq-rcjv",
+        "GHSA-4vvj-4cpr-p986"
     ],
     "moderate": true
 }

--- a/src/payment/checkout/Checkout.jsx
+++ b/src/payment/checkout/Checkout.jsx
@@ -218,6 +218,10 @@ class Checkout extends React.Component {
           address: 'never',
         },
       },
+      wallets: {
+        applePay: 'never',
+        googlePay: 'never',
+      },
     };
 
     // istanbul ignore next


### PR DESCRIPTION
#### Anyone merging to this repository is expected to [promptly release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Description
- Disable wallets in stripe form

We are planning to enable wallet payment options i.e Google Pay and Apple Pay, in our new CT checkout flow. However, since our Stripe account is shared across platforms, these options would also appear on payment.edx.org. Ideally, wallet options should only be displayed for trusted domains. Unfortunately, Stripe does not seem to enforce this setting correctly, as the wallet options are showing up on unregistered domains like payment.edx.org/payment.stage.edx.org. Given that our current Stripe payment logic does not support wallets and Stripe is not respecting domain restrictions, We are disabling wallets as a payment method in the Stripe payment options via code

Currently on stage when google pay is enabled:
<img width="1344" alt="image" src="https://github.com/user-attachments/assets/4ae60f66-2421-498f-8e59-5f9b793a1baf">


## Supporting information
Jira Ticket: https://2u-internal.atlassian.net/browse/SONIC-696


## Checklist
- [x] Consider PCI compliance impact and whether this PR changes how credit card information is handled.
- [x] Intend to [release and monitor](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories) this PR promptly after merge.
