### PR TITLE
fix: Update allowlist security advisories

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -6,7 +6,12 @@
         "GHSA-3h5v-q93c-6h6q",
         "GHSA-vc8w-jr9v-vj7f",
         "GHSA-952p-6rrq-rcjv",
-        "GHSA-4vvj-4cpr-p986"
+        "GHSA-4vvj-4cpr-p986",
+        "GHSA-qwcr-r2fm-qrc7",
+        "GHSA-qw6h-vgh9-j6wx",
+        "GHSA-9wv6-86v2-598j",
+        "GHSA-m6fv-jmcg-4jfg",
+        "GHSA-cm22-4g7w-348p"
     ],
     "moderate": true
 }


### PR DESCRIPTION
This hasn't been updated in a while, there are new security advisories with no resolution that need to be allowlisted to unblock commits. The existing ones haven't been resolved either.