### PR TITLE
fix: Update timestamp format for cohesion

### DIFF
--- a/src/payment/checkout/Checkout.jsx
+++ b/src/payment/checkout/Checkout.jsx
@@ -128,7 +128,7 @@ class Checkout extends React.Component {
   handleSubmitStripe = (formData) => {
     // Red Ventures Cohesion Tagular Event Tracking for Stripe
     const tagularElement = {
-      timestamp: Date.now().toString(),
+      timestamp: Date.now().toISOString(),
       productList: this.getProductList(),
     };
 


### PR DESCRIPTION
I had seen `timestamp` should be a string, however, the type should be more specific in "date-format" for the Cohesion/Beam API for Red Ventures.

Before: `'Thu Nov 07 2024 14:38:18 GMT-0500'`
After: `'2024-11-07T19:38:27.702Z'`