### PR TITLE
fix: Update date to date object for correct formatting for cohesion

### DIFF
--- a/src/payment/checkout/Checkout.jsx
+++ b/src/payment/checkout/Checkout.jsx
@@ -128,7 +128,7 @@ class Checkout extends React.Component {
   handleSubmitStripe = (formData) => {
     // Red Ventures Cohesion Tagular Event Tracking for Stripe
     const tagularElement = {
-      timestamp: Date.now().toISOString(),
+      timestamp: new Date().toISOString(),
       productList: this.getProductList(),
     };
 


### PR DESCRIPTION
My local environment did not error out, but `Date.now()` returns a number not a Date Object, which is not compatible with `toISOString()`.