### PR TITLE
feat: Cohesion identify event firing, modify ConversionTracked

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -42,6 +42,47 @@
               multiparty: true,
           }
       })
+
+      try {
+        if (window.cohesion) {
+          window.cohesion("tagular:ready", function () {
+            window.analytics.ready(function () {
+              const cohesionAnonymId = window.tagular("getAliasSet")["anonymousId"];
+              const segmentAnonymId = window.analytics.user().anonymousId();
+              const segmentUserId = window.analytics.user().id();
+
+              // Segment Identify
+              window.analytics.identify(segmentUserId, {
+                    cohesion_anonymous_id: cohesionAnonymId,
+              });
+
+              // Tagular Identify
+              window.tagular("beam", {
+                "@type": "core.Identify.v1",
+                traits: {},
+                externalIds: [
+                  {
+                      id: segmentAnonymId,
+                      type: "segment_anonymous_id",
+                      collection: "users",
+                      encoding: "none",
+                  },
+                  {
+                      id: cohesionAnonymId,
+                      type: "cohesion_anonymous_id",
+                      collection: "users",
+                      encoding: "none",
+                  },
+                ],
+              });
+            });
+          })
+          } else {
+            console.log('Cohesion is not defined');
+          }
+      } catch(e) {
+        console.log('Cohesion error: ', e);
+      }
     </script>
     <% } %>
   </head>

--- a/src/cohesion/helpers.js
+++ b/src/cohesion/helpers.js
@@ -9,6 +9,12 @@ export const getCorrelationID = () => {
   const COOKIE_NAME = 'tglr_correlation_id';
   const PARAM_NAME = 'correlationId';
 
+  function getDomain() {
+    const { hostname } = window.location;
+    const parts = hostname.split('.');
+    return parts.length > 2 ? parts.slice(-2).join('.') : hostname;
+  }
+
   function getQueryParameter(name) {
     const params = new URLSearchParams(window.location.search);
 
@@ -23,7 +29,7 @@ export const getCorrelationID = () => {
 
   const expirationDate = new Date();
   expirationDate.setMinutes(expirationDate.getMinutes() + 30); // 30 mins expiration from now
-  new Cookies().set(COOKIE_NAME, paramId, { expires: expirationDate });
+  new Cookies().set(COOKIE_NAME, paramId, { expires: expirationDate, domain: `.${getDomain()}` });
 
   return paramId;
 };

--- a/src/payment/checkout/Checkout.jsx
+++ b/src/payment/checkout/Checkout.jsx
@@ -161,9 +161,10 @@ class Checkout extends React.Component {
     if (products || products.length !== 0) {
       products.forEach(product => {
         productList.push({
+          externalId: String(product.courseKey || ''),
           variant: BaseTagularVariant.Courses, // TODO: all are 'courses' now, use translateVariant() in the future
           brand: this.getPartnerName(product), // School or Partner name
-          name: product.title, // Course(s) title
+          name: String(product.title || ''), // Course(s) title
         });
       });
     }

--- a/src/payment/payment-methods/paypal/PayPalButton.jsx
+++ b/src/payment/payment-methods/paypal/PayPalButton.jsx
@@ -20,7 +20,7 @@ const PayPalButton = ({ intl, isProcessing, ...props }) => {
           const elementId = entry.target?.id;
           const tagularElement = {
             elementType: ElementType.Button,
-            position: elementId,
+            position: String(elementId || ''),
             name: 'paypal',
             text: 'PayPal',
           };


### PR DESCRIPTION
- Adding the identify call to provide the identify stitching between Cohesion and Segment.
- Adding a type check to make sure the data sent is always a string since this is what Cohesion expects. Red Ventures data team needs the course key as a workaround to map out the course `variant` that is not possible to do with the data we have in the basket related to "type".
- Modify the getCorrelationId helper, adding the domain.

