### PR TITLE
feat: Add courseKey to ConversionTracked RV event

### DIFF
--- a/src/payment/checkout/Checkout.jsx
+++ b/src/payment/checkout/Checkout.jsx
@@ -161,9 +161,10 @@ class Checkout extends React.Component {
     if (products || products.length !== 0) {
       products.forEach(product => {
         productList.push({
+          externalId: typeof product.courseKey === 'string' ? product.courseKey : '',
           variant: BaseTagularVariant.Courses, // TODO: all are 'courses' now, use translateVariant() in the future
           brand: this.getPartnerName(product), // School or Partner name
-          name: product.title, // Course(s) title
+          name: typeof product.title === 'string' ? product.title : '', // Course(s) title
         });
       });
     }


### PR DESCRIPTION
Red Ventures data team needs the course key as a workaround to map out the course `variant` that is not possible to do with the data we have in the basket related to "type".

Adding a type check to make sure the data sent is always a string since this is what Cohesion expects.