### PR TITLE
fix: Remove existing Tagular cookie with outdated domain metadata

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -12,7 +12,8 @@
         "GHSA-9wv6-86v2-598j",
         "GHSA-m6fv-jmcg-4jfg",
         "GHSA-cm22-4g7w-348p",
-        "GHSA-c7qv-q95q-8v27"
+        "GHSA-c7qv-q95q-8v27",
+        "GHSA-3xgq-45jj-v275"
     ],
     "moderate": true
 }

--- a/src/cohesion/helpers.js
+++ b/src/cohesion/helpers.js
@@ -27,9 +27,14 @@ export const getCorrelationID = () => {
     paramId = uuidv4();
   }
 
+  // If the tagular correlation ID cookie was set before we added the change to
+  // specify the domain, it was automatically added to the current domain.
+  // Always delete the cookie with the current domain
+  new Cookies().remove(COOKIE_NAME, { domain: window.location.hostname, path: '/' });
+
   const expirationDate = new Date();
   expirationDate.setMinutes(expirationDate.getMinutes() + 30); // 30 mins expiration from now
-  new Cookies().set(COOKIE_NAME, paramId, { expires: expirationDate, domain: `.${getDomain()}` });
+  new Cookies().set(COOKIE_NAME, paramId, { expires: expirationDate, domain: `.${getDomain()}`, path: '/' });
 
   return paramId;
 };

--- a/src/payment/PaymentPage.test.jsx
+++ b/src/payment/PaymentPage.test.jsx
@@ -43,6 +43,10 @@ jest.mock('universal-cookie', () => {
     set(cookieName) {
       return MockCookies.result[cookieName];
     }
+
+    remove() {
+      return undefined;
+    }
   }
   return MockCookies;
 });


### PR DESCRIPTION
RV work to fix an unexpected side effect with the `tglr_correlation_id` cookie.

Previously, the correlation ID cookie work did not set a cookie with the domain, so the browser automatically sets the cookie with the current domain. We introduced the change to specify the domain to `.edx.org` here https://github.com/edx/frontend-app-payment/pull/32 

But there are users who have the cookie set with the wrong metadata for the domain (aka the current domain `payment.edx.org`). 

We want to remove these and set a new `tglr_correlation_id` cookie with the correct domain metadata.