### PR TITLE
refactor: Add interval polling for Segment/Cohesion Identify ready

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -42,49 +42,75 @@
               multiparty: true,
           }
       })
-
-      try {
-        if (window.cohesion) {
-          window.cohesion("tagular:ready", function () {
-            window.analytics.ready(function () {
-              const cohesionAnonymId = window.tagular("getAliasSet")["anonymousId"];
-              const segmentAnonymId = window.analytics.user().anonymousId();
-              const segmentUserId = window.analytics.user().id();
-
-              // Segment Identify
-              window.analytics.identify(segmentUserId, {
-                    cohesion_anonymous_id: cohesionAnonymId,
-              });
-
-              // Tagular Identify
-              window.tagular("beam", {
-                "@type": "core.Identify.v1",
-                traits: {},
-                externalIds: [
-                  {
-                      id: segmentAnonymId,
-                      type: "segment_anonymous_id",
-                      collection: "users",
-                      encoding: "none",
-                  },
-                  {
-                      id: cohesionAnonymId,
-                      type: "cohesion_anonymous_id",
-                      collection: "users",
-                      encoding: "none",
-                  },
-                ],
-              });
-            });
-          })
-          } else {
-            console.log('Cohesion is not defined');
-          }
-      } catch(e) {
-        console.log('Cohesion error: ', e);
-      }
     </script>
     <% } %>
+
+    <script async>
+      function waitForSegmentAnalyticsReady(callback, timeoutTime = 4000) { // Default 4 sec, this is an async script
+        const intervalTime = 100; // 100 ms
+        let elapsedTime = 0;
+
+        const interval = setInterval(() => {
+          if (window.analytics && typeof window.analytics.ready === 'function') {
+            clearInterval(interval);
+            callback();
+          } else {
+            // Stop polling if Segment doesn't load in expected time interval
+            elapsedTime += intervalTime;
+            if (elapsedTime >= timeoutTime) {
+              clearInterval(interval);
+              console.log('Segment analytics did not load in the expected timeout')
+            }
+          }
+        }, intervalTime);
+      }
+
+      waitForSegmentAnalyticsReady(() => {
+        window.analytics.ready(() => {
+          console.log('Segment analytics is ready');
+          try {
+            if (window.cohesion) {
+              window.cohesion("tagular:ready", function () {
+                window.analytics.ready(function () {
+                  const cohesionAnonymId = window.tagular("getAliasSet")["anonymousId"];
+                  const segmentAnonymId = window.analytics.user().anonymousId();
+                  const segmentUserId = window.analytics.user().id();
+
+                  // Segment Identify
+                  window.analytics.identify(segmentUserId, {
+                        cohesion_anonymous_id: cohesionAnonymId,
+                  });
+
+                  // Tagular Identify
+                  window.tagular("beam", {
+                    "@type": "core.Identify.v1",
+                    traits: {},
+                    externalIds: [
+                      {
+                          id: segmentAnonymId,
+                          type: "segment_anonymous_id",
+                          collection: "users",
+                          encoding: "none",
+                      },
+                      {
+                          id: cohesionAnonymId,
+                          type: "cohesion_anonymous_id",
+                          collection: "users",
+                          encoding: "none",
+                      },
+                    ],
+                  });
+                });
+              })
+              } else {
+                console.log('Cohesion is not defined');
+              }
+          } catch(e) {
+            console.log('Cohesion error: ', e);
+          }
+        })
+      }, 4000);
+    </script>
   </head>
   <body>
     <div id="root">


### PR DESCRIPTION
There is an issue where we call `window.analytics` before it's defined, even through the order of the Segment script is correct when the other Cohesion/RV related script is loaded. 

Adding an interval and polling based on a timeout that if Segment analytics is not defined in 4 seconds, it will stop polling (to avoid polling indefinitely).
